### PR TITLE
Updated Correct Version Information

### DIFF
--- a/bin/templates/cordova/version
+++ b/bin/templates/cordova/version
@@ -25,7 +25,7 @@
 */
 
 // Coho updates this line
-const VERSION = '5.1.0-dev';
+const VERSION = '1.0.0-dev';
 
 module.exports.version = VERSION;
 

--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -19,7 +19,7 @@
     under the License.
 */
 (function () {
-    const PLATFORM_VERSION_BUILD_LABEL = '5.1.0-dev';
+    const PLATFORM_VERSION_BUILD_LABEL = '1.0.0-dev';
     // file: src/scripts/require.js
 
     /* jshint -W079 */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-electron",
-  "version": "1.0.0",
+  "version": "1.0.0-dev",
   "description": "electron apps as a target for cordova developers",
   "main": "bin/templates/cordova/Api.js",
   "bin": "bin/create",


### PR DESCRIPTION
### Platforms affected
electron

### What does this PR do?
- Corrects the version information of the platform to `1.0.0-dev`

> Since the platform has never been released, this PR ensure that we release on the proper version.

### What testing has been done on this change?
```
$ npm t
```