### PR TITLE
Create electron settings json

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -77,5 +77,8 @@ module.exports.createProject = (project_path, package_name, project_name, option
     // copy main.js
     fs.copySync(path.join(ROOT, 'bin/templates/project/main.js'), path.join(platform_www, 'main.js'), { overwrite: false });
 
+    // copy cdv-electron-settings.json
+    fs.copySync(path.join(ROOT, 'bin/templates/project/cdv-electron-settings.json'), path.join(platform_www, 'cdv-electron-settings.json'), { overwrite: false });
+
     return Promise.resolve();
 };

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -69,9 +69,33 @@ module.exports.prepare = function (cordovaProject, options) {
         .configure(this.config)
         .write();
 
+    // update Electron settings in .json file
+    (new SettingJson(this.locations.www))
+        .configure(options.options)
+        .write();
+
     // update project according to config.xml changes.
     return this.parser.update_project(this.config, options);
 };
+
+class SettingJson {
+    constructor (wwwDir) {
+        this.path = path.join(wwwDir, 'cdv-electron-settings.json');
+        this.package = require(this.path);
+    }
+
+    configure (config) {
+        if (config) {
+            this.package.isRelease = (typeof (config.release) !== 'undefined') ? config.release : false;
+        }
+
+        return this;
+    }
+
+    write () {
+        fs.writeFileSync(this.path, JSON.stringify(this.package, null, 2), 'utf8');
+    }
+}
 
 class PackageJson {
     constructor (wwwDir) {

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,0 +1,3 @@
+{
+    "isRelease": false
+}

--- a/bin/templates/project/main.js
+++ b/bin/templates/project/main.js
@@ -22,6 +22,8 @@ const electron = require('electron');
 const app = electron.app;
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow;
+// Electron settings from .json file.
+const cdvElectronSettings = require('./cdv-electron-settings.json');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -39,7 +41,9 @@ function createWindow () {
     });
 
     // Open the DevTools.
-    mainWindow.webContents.openDevTools();
+    if (!cdvElectronSettings.isRelease) {
+        mainWindow.webContents.openDevTools();
+    }
 
     // Emitted when the window is closed.
     mainWindow.on('closed', () => {


### PR DESCRIPTION
------------------------------------------
### Platforms affected
------------------------------------------

Electron


------------------------------------------
### What does this PR do?
------------------------------------------

Create a setting json file, where we could store necessary settings for electron platform.

When running or building electron platform users can pass in `--release` flag through cli. 
Depending on that flag set an appropriate `isRelease` value.
Later check that value `isRelease` value and depending on that value, open or close the Dev Tools window on the launch.

This file could be used in the future to store other necessary options and configs for electron platform. 

------------------------------------------
### What testing has been done on this change?
------------------------------------------

Tested 4 cases with 3 node version 6.16.0, 8.15.0 and 10.15.0 using following tests.

- **First created a Cordova project and added electron platform:**

```
$ npx cordova@nightly create cordova-project
$ cd cordova-project
$ npx cordova@nightly platform add github:Gedasga/cordova-electron#settings-json
```

The steps above uses Nightly to test the Electron for Cordova 9 release.

------------------------------------------
- **Then ran electron platform, when no flag is passed:**

```
$ npx cordova@nightly run electron
```

**Results:**
_Launches electron and opens the Dev Tools window. (Default behaviour)_
```
{
  "isRelease": false
}
```

------------------------------------------
- **When passed flag other than `--release` (in this case `--debug`):**

```
$ npx cordova@nightly run electron --debug
```

**Results:**
_Launches electron and opens the Dev Tools window._
```
{
  "isRelease": false
}
```

------------------------------------------
- **When passed `--release` flag:**

```
$ npx cordova@nightly run electron --release
```

**Results:**
_Launches electron, but does not open the Dev Tools window._
```
{
  "isRelease": true
}
```
------------------------------------------
- **When passed multiple flag:**

```
$ npx cordova@nightly run electron --release --device
```

**Results:**
_Launches electron, but does not open the Dev Tools window._
```
{
  "isRelease": true
}
```
------------------------------------------

- **And ran automated tests.**

```
$ npm t

21 specs, 0 failures
Finished in 457.915 seconds
-----------------------|----------|----------|----------|----------|-------------------|
File                   |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------------|----------|----------|----------|----------|-------------------|
All files              |    34.21 |    17.71 |    16.95 |    34.23 |                   |
 lib                   |    92.31 |       50 |      100 |    92.31 |                   |
  create.js            |    92.31 |       50 |      100 |    92.31 |             44,50 |
 templates/cordova     |       26 |    14.77 |    14.04 |    26.15 |                   |
  Api.js               |    25.19 |     8.82 |     12.9 |     25.4 |... 52,356,374,375 |
  handler.js           |    21.43 |    16.67 |     6.25 |    21.43 |... 13,116,131,132 |
  parser.js            |    37.04 |     62.5 |       30 |    37.04 |... 7,83,87,90,103 |
 templates/cordova/lib |      100 |      100 |      100 |      100 |                   |
  check_reqs.js        |      100 |      100 |      100 |      100 |                   |
-----------------------|----------|----------|----------|----------|-------------------|
```