### PR TITLE
Electron Build Improvements

### DIFF
--- a/bin/templates/cordova/lib/build/base.json
+++ b/bin/templates/cordova/lib/build/base.json
@@ -2,14 +2,16 @@
   "config": {
     "appId": "${APP_ID}",
     "productName": "${APP_TITLE}",
-    
+
     "directories": {
       "app": "${APP_WWW_DIR}",
       "output": "${APP_BUILD_DIR}"
     },
-    
+
+    "electronVersion": "4.0.1",
+
     "electronDownload": {
-      "version": "3.0.6"
+      "version": "4.0.1"
     }
   }
 }

--- a/bin/templates/cordova/lib/build/linux.json
+++ b/bin/templates/cordova/lib/build/linux.json
@@ -2,7 +2,6 @@
   "linux": [],
   "config": {
     "linux": {
-      "type": "${BUILD_TYPE}",
       "maintainer": "${APP_AUTHOR}",
       "target": [
         {


### PR DESCRIPTION
### Platforms affected
electron

### What does this PR do?
- Removed the `type` param from Linux default build configs. This is not a valid param for Linux and causes builds to stop.
- Bumped and pinned the supported Electron version to `4.0.1` to match with package.json.

### What testing has been done on this change?
```
$ npx cordova@nightly create electronTest com.foobar.electronTest electronTest && cd $_
$ npx cordova@nightly platform add github:erisu/cordova-electron\#build-fix
$ npx cordova@nightly build electron
```
