### PR TITLE
Refactor prepare.js, increase test coverage

### DIFF
--- a/bin/templates/cordova/lib/ManifestJsonParser.js
+++ b/bin/templates/cordova/lib/ManifestJsonParser.js
@@ -1,0 +1,132 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const fs = require('fs-extra');
+const path = require('path');
+
+class ManifestJsonParser {
+    constructor (wwwDir) {
+        this.path = path.join(wwwDir, 'manifest.json');
+        this.www = wwwDir;
+        this.manifest = {
+            background_color: '#FFF',
+            display: 'standalone',
+            orientation: 'any',
+            start_url: 'index.html'
+        };
+    }
+
+    configureIcons (config) {
+        /**
+        * given a tag like this :
+        * <icon src="res/ios/icon.png" width="57" height="57" density="mdpi" />
+        *
+        * configParser returns icons that look like this :
+        * {
+        *      src: 'res/ios/icon.png',
+        *      target: undefined,
+        *      density: 'mdpi',
+        *      platform: null,
+        *      width: 57,
+        *      height: 57
+        * }
+        *
+        * manifest expects them to be like this :
+        * {
+        *      "src": "images/touch/icon-128x128.png",
+        *      "type": "image/png",
+        *      "sizes": "128x128"
+        * }
+        */
+        const icons = config.getStaticResources(this.platform, 'icon')
+            .map((icon) => ({
+                src: icon.src,
+                type: 'image/png',
+                sizes: `${icon.width}x${icon.height}`
+            }));
+
+        if (icons) this.manifest.icons = icons;
+
+        return this;
+    }
+
+    configureOrientation (config) {
+        // orientation
+        // <preference name="Orientation" value="landscape" />
+        const oriPref = config.getGlobalPreference('Orientation');
+        if (oriPref === 'landscape' || oriPref === 'portrait') {
+            this.manifest.orientation = oriPref;
+        }
+
+        return this;
+    }
+
+    configureStartUrl (config) {
+        // get start_url
+        const contentNode = config.doc.find('content');
+        if (contentNode) this.manifest.start_url = contentNode.attrib.src;
+
+        return this;
+    }
+
+    configureThemeColor (config) {
+        if (this.manifest.start_url) {
+            const startUrlPath = path.join(this.www, this.manifest.start_url);
+
+            if (fs.existsSync(startUrlPath)) {
+                // fetch start url file content and parse for theme-color.
+                const contents = fs.readFileSync(startUrlPath, 'utf-8');
+                const result = /<meta(?=[^>]*name="theme-color")\s[^>]*content="([^>]*)"/i.exec(contents);
+
+                // If theme-color exists, the value is in index 1.
+                if (result && result.length >= 2) this.manifest.theme_color = result[1];
+            }
+        }
+
+        if (this.manifest.start_url && !this.manifest.theme_color) {
+            const themeColor = config.getGlobalPreference('StatusBarBackgroundColor');
+            if (themeColor) this.manifest.theme_color = themeColor;
+        }
+
+        return this;
+    }
+
+    configure (config) {
+        if (config) {
+            if (config.name()) this.manifest.name = config.name();
+            if (config.shortName()) this.manifest.short_name = config.shortName();
+            if (config.packageName()) this.manifest.version = config.packageName();
+            if (config.description()) this.manifest.description = config.description();
+            if (config.author()) this.manifest.author = config.author();
+
+            this.configureIcons(config)
+                .configureOrientation(config)
+                .configureStartUrl(config)
+                .configureThemeColor(config);
+        }
+
+        return this;
+    }
+
+    write () {
+        fs.writeFileSync(this.path, JSON.stringify(this.manifest, null, 2), 'utf8');
+    }
+}
+
+module.exports = ManifestJsonParser;

--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -1,0 +1,61 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const fs = require('fs-extra');
+const path = require('path');
+
+class PackageJsonParser {
+    constructor (wwwDir) {
+        this.path = path.join(wwwDir, 'package.json');
+        this.www = wwwDir;
+        this.package = {
+            main: 'main.js'
+        };
+    }
+
+    configure (config) {
+        if (config) {
+            this.package.name = config.packageName() || 'io.cordova.hellocordova';
+            this.package.displayName = config.name() || 'HelloCordova';
+            this.package.version = config.version() || '1.0.0';
+            this.package.description = config.description() || 'A sample Apache Cordova application that responds to the deviceready event.';
+
+            this.configureHomepage(config);
+            this.configureLicense(config);
+
+            this.package.author = config.author() || 'Apache Cordova Team';
+        }
+
+        return this;
+    }
+
+    configureHomepage (config) {
+        this.package.homepage = (config.doc.find('author') && config.doc.find('author').attrib['href']) || 'https://cordova.io';
+    }
+
+    configureLicense (config) {
+        this.package.license = (config.doc.find('license') && config.doc.find('license').text && config.doc.find('license').text.trim()) || 'Apache-2.0';
+    }
+
+    write () {
+        fs.writeFileSync(this.path, JSON.stringify(this.package, null, 2), 'utf8');
+    }
+}
+
+module.exports = PackageJsonParser;

--- a/bin/templates/cordova/lib/SettingJsonParser.js
+++ b/bin/templates/cordova/lib/SettingJsonParser.js
@@ -1,0 +1,42 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const fs = require('fs-extra');
+const path = require('path');
+
+class SettingJsonParser {
+    constructor (wwwDir) {
+        this.path = path.join(wwwDir, 'cdv-electron-settings.json');
+        this.package = require(this.path);
+    }
+
+    configure (config) {
+        if (config) {
+            this.package.isRelease = (typeof (config.release) !== 'undefined') ? config.release : false;
+        }
+
+        return this;
+    }
+
+    write () {
+        fs.writeFileSync(this.path, JSON.stringify(this.package, null, 2), 'utf8');
+    }
+}
+
+module.exports = SettingJsonParser;

--- a/tests/spec/fixtures/test-config-1.xml
+++ b/tests/spec/fixtures/test-config-1.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="whatever" version="1.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>HelloWorld</name>
+    <description>
+        A sample Apache Cordova application.
+    </description>
+    <author email="dev@cordova.com" href="http://cordova.io">
+        Cordova Team
+    </author>
+    <license>Apache 2.0 License</license>
+    <preference name="Orientation" value="portrait" />
+    <content src="index.html" main="index.js" />
+    <plugin name="cordova-plugin-whitelist" spec="1" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <allow-intent href="tel:*" />
+    <allow-intent href="sms:*" />
+    <allow-intent href="mailto:*" />
+    <allow-intent href="geo:*" />
+    <platform name="android">
+        <allow-intent href="market:*" />
+    </platform>
+    <platform name="ios">
+        <allow-intent href="itms:*" />
+        <allow-intent href="itms-apps:*" />
+    </platform>
+    <icon src="res/electron/cordova.png"  width="16" height="16"/>
+    <platform name="electron">
+        <icon src="res/electron/cordova.png"/>
+        <icon src="res/electron/cordova@1.5.png" />
+        <icon src="res/electron/cordova@2.png" />
+        <icon src="res/electron/cordova@3.png" />
+        <icon src="res/electron/cordova@4.png" />
+        <icon src="res/electron/cordova@8.png" />
+        <icon src="res/electron/cordova@16.png" />
+        <icon src="res/electron/cordova_512.png" target="installer" />
+    </platform>
+    <engine name="electron" spec="github:gedasga/cordova-electron#app-icons" />
+</widget>

--- a/tests/spec/fixtures/test-config-2.xml
+++ b/tests/spec/fixtures/test-config-2.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="whatever" version="1.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name short="Hello">HelloWorld</name>
+    <description>
+        A sample Apache Cordova application.
+    </description>
+    <author email="dev@cordova.com" href="http://cordova.io">
+        Cordova Team
+    </author>
+    <license>Apache 2.0 License</license>
+    <preference name="Orientation" value="landscape" />
+    <preference name="StatusBarBackgroundColor" value="0xff0000ff"/>
+    <plugin name="cordova-plugin-whitelist" spec="1" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <allow-intent href="tel:*" />
+    <allow-intent href="sms:*" />
+    <allow-intent href="mailto:*" />
+    <allow-intent href="geo:*" />
+    <platform name="android">
+        <allow-intent href="market:*" />
+    </platform>
+    <platform name="ios">
+        <allow-intent href="itms:*" />
+        <allow-intent href="itms-apps:*" />
+    </platform>
+    <platform name="electron">
+        <icon src="res/electron/cordova.png" />
+        <icon src="res/electron/cordova@1.5.png" />
+        <icon src="res/electron/cordova@2.png" />
+        <icon src="res/electron/cordova@3.png" />
+        <icon src="res/electron/cordova@4.png" />
+        <icon src="res/electron/cordova@8.png" />
+        <icon src="res/electron/cordova@16.png" />
+        <icon src="res/electron/cordova_512.png" target="installer" />
+    </platform>
+    <engine name="electron" spec="github:gedasga/cordova-electron#app-icons" />
+</widget>

--- a/tests/spec/fixtures/test-config-empty.xml
+++ b/tests/spec/fixtures/test-config-empty.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget>
+    <name />
+    <description />
+    <author />
+    <content />
+</widget>

--- a/tests/spec/unit/templates/cordova/lib/ManifestJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/ManifestJsonParser.spec.js
@@ -1,0 +1,239 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const rewire = require('rewire');
+const path = require('path');
+const ConfigParser = require('cordova-common').ConfigParser;
+
+const FIXTURES = path.join(__dirname, '..', '..', '..', '..', 'fixtures');
+
+// Create a real config object before mocking out everything.
+const cfg1 = new ConfigParser(path.join(FIXTURES, 'test-config-1.xml'));
+const cfg2 = new ConfigParser(path.join(FIXTURES, 'test-config-2.xml'));
+const cfgEmpty = new ConfigParser(path.join(FIXTURES, 'test-config-empty.xml'));
+
+describe('Testing ManifestJsonParser.js:', () => {
+    let ManifestJsonParser;
+    let locations;
+
+    beforeEach(() => {
+        ManifestJsonParser = rewire('../../../../../../bin/templates/cordova/lib/ManifestJsonParser');
+
+        locations = {
+            buildRes: path.join('mock', 'build-res'),
+            www: path.join('mock', 'www'),
+            configXml: path.join('mock', 'config.xml')
+        };
+    });
+
+    describe('ManifestJson class', () => {
+        let manifestJsonParser;
+
+        beforeEach(() => {
+            manifestJsonParser = ManifestJsonParser.__get__('ManifestJsonParser');
+        });
+
+        it('should should be defined.', () => {
+            expect(manifestJsonParser).toBeDefined();
+        });
+
+        it('should set initial value correctly.', () => {
+            manifestJsonParser = new ManifestJsonParser(locations.www);
+
+            // mock manifest JSON Object
+            const manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'any',
+                start_url: 'index.html'
+            };
+
+            expect(manifestJsonParser.path).toEqual(path.join('mock', 'www', 'manifest.json'));
+            expect(manifestJsonParser.www).toEqual(locations.www);
+            expect(manifestJsonParser.manifest).toEqual(manifestJsonObj);
+        });
+
+        it('should return when config xml is not defined.', () => {
+            manifestJsonParser = new ManifestJsonParser(locations.www).configure(undefined);
+
+            // mock manifest JSON Object
+            const manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'any',
+                start_url: 'index.html'
+            };
+
+            expect(manifestJsonParser.manifest).toEqual(manifestJsonObj);
+        });
+
+        it('should set manifest json object values to default, when config xml is empty.', () => {
+            manifestJsonParser = new ManifestJsonParser(locations.www).configure(cfgEmpty);
+
+            // mock manifest JSON Object
+            const manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'any',
+                start_url: undefined,
+                icons: [ ]
+            };
+
+            expect(manifestJsonParser.manifest).toEqual(manifestJsonObj);
+        });
+
+        it('should read and set manifest json object values from the first config xml.', () => {
+            manifestJsonParser = new ManifestJsonParser(locations.www).configure(cfg1);
+
+            // mock manifest JSON Object
+            const manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'portrait',
+                start_url: 'index.html',
+                name: 'HelloWorld',
+                short_name: 'HelloWorld',
+                version: 'whatever',
+                description: 'A sample Apache Cordova application.',
+                author: 'Cordova Team',
+                icons: [ { src: 'res/electron/cordova.png', type: 'image/png', sizes: '16x16' } ]
+            };
+            expect(manifestJsonParser.manifest).toEqual(manifestJsonObj);
+        });
+
+        it('should read and set manifest json object values from second config xml.', () => {
+            manifestJsonParser = new ManifestJsonParser(locations.www).configure(cfg2);
+
+            // mock manifest JSON Object
+            const manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'landscape',
+                start_url: 'index.html',
+                name: 'HelloWorld',
+                short_name: 'Hello',
+                theme_color: '0xff0000ff',
+                version: 'whatever',
+                description: 'A sample Apache Cordova application.',
+                author: 'Cordova Team',
+                icons: [ ]
+            };
+            expect(manifestJsonParser.manifest).toEqual(manifestJsonObj);
+        });
+
+        it('should be called if start_url is defined in config xml.', () => {
+            const existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            const readFileSyncSpy = jasmine.createSpy('readFileSync').and.returnValue('<meta name="theme-color" content="#33363b">');
+            manifestJsonParser.__set__('fs', { readFileSync: readFileSyncSpy, existsSync: existsSyncSpy });
+
+            manifestJsonParser = new ManifestJsonParser(locations.www).configureThemeColor(cfg1);
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(readFileSyncSpy).toHaveBeenCalled();
+        });
+
+        it('should not be called if start_url is not defined in config xml.', () => {
+            const existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            const readFileSyncSpy = jasmine.createSpy('readFileSync');
+            manifestJsonParser.__set__('fs', { readFileSync: readFileSyncSpy, existsSync: existsSyncSpy });
+
+            manifestJsonParser = new ManifestJsonParser(locations.www).configureThemeColor(cfgEmpty);
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(readFileSyncSpy).toHaveBeenCalled();
+        });
+
+        it('should write provided data when config xml is empty.', () => {
+            const existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            const readFileSyncSpy = jasmine.createSpy('readFileSync');
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            manifestJsonParser.__set__('fs', { readFileSync: readFileSyncSpy, existsSync: existsSyncSpy, writeFileSync: writeFileSyncSpy });
+
+            manifestJsonParser = new ManifestJsonParser(locations.www).configure(cfgEmpty).write();
+
+            expect(existsSyncSpy).not.toHaveBeenCalled();
+            expect(readFileSyncSpy).not.toHaveBeenCalled();
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            // mock manifest JSON Object
+            let manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'any',
+                icons: [ ]
+            };
+
+            const manifestPath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(manifestPath).toEqual(path.join('mock', 'www', 'manifest.json'));
+
+            // get manifest json file content and remove white spaces
+            let manifestFile = writeFileSyncSpy.calls.argsFor(0)[1];
+
+            // convert to remove white space
+            manifestFile = manifestFile.replace(/\s+/g, '');
+            manifestJsonObj = JSON.stringify(manifestJsonObj).replace(/\s/g, '');
+            expect(manifestFile).toEqual(manifestJsonObj);
+
+            const manifestFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(manifestFormat).toEqual('utf8');
+        });
+
+        it('should write manifest json object values from config xml.', () => {
+            const existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            const readFileSyncSpy = jasmine.createSpy('readFileSync');
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            manifestJsonParser.__set__('fs', { readFileSync: readFileSyncSpy, existsSync: existsSyncSpy, writeFileSync: writeFileSyncSpy });
+
+            manifestJsonParser = new ManifestJsonParser(locations.www).configure(cfg1).write();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(readFileSyncSpy).toHaveBeenCalled();
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            // mock manifest JSON Object
+            let manifestJsonObj = {
+                background_color: '#FFF',
+                display: 'standalone',
+                orientation: 'portrait',
+                start_url: 'index.html',
+                name: 'HelloWorld',
+                short_name: 'HelloWorld',
+                version: 'whatever',
+                description: 'A sample Apache Cordova application.',
+                author: 'Cordova Team',
+                icons: [ { src: 'res/electron/cordova.png', type: 'image/png', sizes: '16x16' } ]
+            };
+
+            const manifestPath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(manifestPath).toEqual(path.join('mock', 'www', 'manifest.json'));
+
+            // get manifest json file content and remove white spaces
+            let manifestFile = writeFileSyncSpy.calls.argsFor(0)[1];
+
+            // convert to remove white space
+            manifestFile = manifestFile.replace(/\s+/g, '');
+            manifestJsonObj = JSON.stringify(manifestJsonObj).replace(/\s/g, '');
+            expect(manifestFile).toEqual(manifestJsonObj);
+
+            const manifestFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(manifestFormat).toEqual('utf8');
+        });
+
+    });
+});

--- a/tests/spec/unit/templates/cordova/lib/PackageJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/PackageJsonParser.spec.js
@@ -1,0 +1,193 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const rewire = require('rewire');
+const path = require('path');
+const ConfigParser = require('cordova-common').ConfigParser;
+
+const FIXTURES = path.join(__dirname, '..', '..', '..', '..', 'fixtures');
+
+// Create a real config object before mocking out everything.
+const cfg = new ConfigParser(path.join(FIXTURES, 'test-config-1.xml'));
+const cfgEmpty = new ConfigParser(path.join(FIXTURES, 'test-config-empty.xml'));
+
+describe('Testing PackageJsonParser.js:', () => {
+    let PackageJsonParser;
+    let locations;
+
+    beforeEach(() => {
+        PackageJsonParser = rewire('../../../../../../bin/templates/cordova/lib/PackageJsonParser');
+
+        locations = {
+            buildRes: path.join('mock', 'build-res'),
+            www: path.join('mock', 'www'),
+            configXml: path.join('mock', 'config.xml')
+        };
+    });
+
+    describe('PackageJson class', () => {
+        let packageJsonParser;
+
+        beforeEach(() => {
+            packageJsonParser = PackageJsonParser.__get__('PackageJsonParser');
+        });
+
+        it('should should be defined.', () => {
+            expect(packageJsonParser).toBeDefined();
+        });
+
+        it('should set initial value correctly.', () => {
+            packageJsonParser = new PackageJsonParser(locations.www);
+
+            // mock package JSON Object
+            const packageJsonObj = { main: 'main.js' };
+
+            expect(packageJsonParser.path).toEqual(path.join('mock', 'www', 'package.json'));
+            expect(packageJsonParser.www).toEqual(locations.www);
+            expect(packageJsonParser.package).toEqual(packageJsonObj);
+        });
+
+        it('should return when config xml is not defined.', () => {
+            packageJsonParser = new PackageJsonParser(locations.www).configure(undefined);
+
+            // mock package JSON Object
+            const packageJsonObj = { main: 'main.js' };
+
+            expect(packageJsonParser.package).toEqual(packageJsonObj);
+        });
+
+        it('should set package json object values to default, when config xml is empty.', () => {
+            packageJsonParser = new PackageJsonParser(locations.www).configure(cfgEmpty);
+
+            // mock package JSON Object
+            const packageJsonObj = {
+                package:
+                    {
+                        main: 'main.js',
+                        name: 'io.cordova.hellocordova',
+                        displayName: 'HelloCordova',
+                        version: '1.0.0',
+                        description: 'A sample Apache Cordova application that responds to the deviceready event.',
+                        homepage: 'https://cordova.io',
+                        license: 'Apache-2.0',
+                        author: 'Apache Cordova Team'
+                    }
+            };
+
+            expect(packageJsonParser.package).toEqual(packageJsonObj.package);
+        });
+
+        it('should read and set package json object values from config xml.', () => {
+            packageJsonParser = new PackageJsonParser(locations.www).configure(cfg);
+
+            // mock package JSON Object
+            const packageJsonObj = {
+                package:
+                    {
+                        main: 'main.js',
+                        name: 'whatever',
+                        displayName: 'HelloWorld',
+                        version: '1.1.1',
+                        description: 'A sample Apache Cordova application.',
+                        homepage: 'http://cordova.io',
+                        license: 'Apache 2.0 License',
+                        author: 'Cordova Team'
+                    }
+            };
+
+            expect(packageJsonParser.package).toEqual(packageJsonObj.package);
+        });
+
+        it('should write provided data when config xml is empty.', () => {
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            packageJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+
+            packageJsonParser = new PackageJsonParser(locations.www).configure(cfgEmpty).write();
+
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            // mock package JSON Object
+            let packageJsonObj = {
+                package:
+                    {
+                        main: 'main.js',
+                        name: 'io.cordova.hellocordova',
+                        displayName: 'HelloCordova',
+                        version: '1.0.0',
+                        description: 'A sample Apache Cordova application that responds to the deviceready event.',
+                        homepage: 'https://cordova.io',
+                        license: 'Apache-2.0',
+                        author: 'Apache Cordova Team'
+                    }
+            };
+
+            const packagePath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(packagePath).toEqual(path.join('mock', 'www', 'package.json'));
+
+            // get package json file content and remove white spaces
+            let packageFile = writeFileSyncSpy.calls.argsFor(0)[1];
+
+            // convert to remove white space
+            packageFile = packageFile.replace(/\s+/g, '');
+            packageJsonObj = JSON.stringify(packageJsonObj.package).replace(/\s/g, '');
+            expect(packageFile).toEqual(packageJsonObj);
+
+            const packageFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(packageFormat).toEqual('utf8');
+        });
+
+        it('should write package json object values from config xml.', () => {
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            packageJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+
+            packageJsonParser = new PackageJsonParser(locations.www).configure(cfg).write();
+
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            // mock package JSON Object
+            let packageJsonObj = {
+                package:
+                    {
+                        main: 'main.js',
+                        name: 'whatever',
+                        displayName: 'HelloWorld',
+                        version: '1.1.1',
+                        description: 'A sample Apache Cordova application.',
+                        homepage: 'http://cordova.io',
+                        license: 'Apache 2.0 License',
+                        author: 'Cordova Team'
+                    }
+            };
+
+            const packagePath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(packagePath).toEqual(path.join('mock', 'www', 'package.json'));
+
+            // get package json file content and remove white spaces
+            let packageFile = writeFileSyncSpy.calls.argsFor(0)[1];
+
+            // convert to remove white space
+            packageFile = packageFile.replace(/\s+/g, '');
+            packageJsonObj = JSON.stringify(packageJsonObj.package).replace(/\s/g, '');
+            expect(packageFile).toEqual(packageJsonObj);
+
+            const packageFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(packageFormat).toEqual('utf8');
+        });
+    });
+});

--- a/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
@@ -1,0 +1,177 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const rewire = require('rewire');
+const path = require('path');
+
+describe('Testing SettingJsonParser.js:', () => {
+    let SettingJsonParser;
+    let locations;
+
+    beforeEach(() => {
+        SettingJsonParser = rewire('../../../../../../bin/templates/cordova/lib/SettingJsonParser');
+
+        locations = {
+            buildRes: path.join('mock', 'build-res'),
+            www: path.join('mock', 'www'),
+            configXml: path.join('mock', 'config.xml')
+        };
+    });
+
+    describe('SettingJson class', () => {
+        let settingJsonParser;
+        let requireSpy;
+        let options;
+
+        beforeEach(() => {
+            settingJsonParser = SettingJsonParser.__get__('SettingJsonParser');
+
+            requireSpy = jasmine.createSpy('require').and.returnValue({});
+            settingJsonParser.__set__({ require: requireSpy });
+        });
+
+        it('should should be defined.', () => {
+            expect(settingJsonParser).toBeDefined();
+        });
+
+        it('should be called and package equal to false, if settings json does not exist.', () => {
+            requireSpy = jasmine.createSpy('require').and.returnValue(false);
+            settingJsonParser.__set__({ require: requireSpy });
+
+            settingJsonParser = new SettingJsonParser(locations.www);
+
+            expect(requireSpy).toHaveBeenCalled();
+            expect(settingJsonParser.package).toEqual(false);
+        });
+
+        it('should be called and package equal to true, if settings json does exist.', () => {
+            settingJsonParser = new SettingJsonParser(locations.www);
+
+            expect(requireSpy).toHaveBeenCalled();
+            expect(settingJsonParser.package).toEqual({});
+        });
+
+        it('should be equal to undefined, when config file is undefined.', () => {
+            // mock options data
+            options = { options: { argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(undefined);
+
+            expect(requireSpy).toHaveBeenCalled();
+            expect(settingJsonParser.package.isRelease).toEqual(undefined);
+        });
+
+        it('should be equal to false, when no flag is set.', () => {
+            // mock options data
+            options = { options: { argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
+
+            expect(requireSpy).toHaveBeenCalled();
+            expect(settingJsonParser.package.isRelease).toEqual(false);
+        });
+
+        it('should be equal to false, when debug flag is set.', () => {
+            // mock options data
+            options = { options: { debug: true, argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
+
+            expect(requireSpy).toHaveBeenCalled();
+            expect(settingJsonParser.package.isRelease).toEqual(false);
+        });
+
+        it('should be equal to true, when release flag is set.', () => {
+            // mock options data
+            options = { options: { release: true, argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
+
+            expect(requireSpy).toHaveBeenCalled();
+            expect(settingJsonParser.package.isRelease).toEqual(true);
+        });
+
+        it('should write provided data, when no flag is set.', () => {
+            let writeFileSyncSpy;
+            writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+
+            options = { options: { argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
+
+            // get settings json file content and remove white spaces
+            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
+            settingsFile = settingsFile.replace(/\s+/g, '');
+            expect(settingsFile).toEqual('{"isRelease":false}');
+
+            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(settingsFormat).toEqual('utf8');
+        });
+
+        it('should write provided data, when debug flag is set.', () => {
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+
+            options = { options: { debug: true, argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
+
+            // get settings json file content and remove white spaces
+            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
+            settingsFile = settingsFile.replace(/\s+/g, '');
+            expect(settingsFile).toEqual('{"isRelease":false}');
+
+            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(settingsFormat).toEqual('utf8');
+        });
+
+        it('should write provided data.', () => {
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+
+            options = { options: { release: true, argv: [] } };
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+
+            expect(writeFileSyncSpy).toHaveBeenCalled();
+
+            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
+            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
+
+            // get settings json file content and remove white spaces
+            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
+            settingsFile = settingsFile.replace(/\s+/g, '');
+            expect(settingsFile).toEqual('{"isRelease":true}');
+
+            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
+            expect(settingsFormat).toEqual('utf8');
+        });
+    });
+});

--- a/tests/spec/unit/templates/cordova/lib/prepare.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/prepare.spec.js
@@ -62,7 +62,9 @@ describe('Testing prepare.js:', () => {
 
         locations = {
             buildRes: path.join('mock', 'build-res'),
-            www: path.join('mock', 'www')
+            www: path.join('mock', 'www'),
+            configXml: path.join('mock', 'config.xml'),
+            platformRootDir: path.join('mock', 'platform_www')
         };
 
         emitSpy = jasmine.createSpy('emit');
@@ -76,132 +78,11 @@ describe('Testing prepare.js:', () => {
         });
     });
 
-    describe('SettingJon class', () => {
-        let SettingJson;
-        let requireSpy;
-        let options;
+    describe('module.exports.prepare method', () => {
+        it('should be defined.', () => {
+            const exportPrepare = prepare.__get__('module.exports.prepare');
 
-        beforeEach(() => {
-            SettingJson = prepare.__get__('SettingJson');
-
-            requireSpy = jasmine.createSpy('require').and.returnValue({});
-            prepare.__set__({ require: requireSpy });
-        });
-
-        it('should be called and package equal to false, if settings json does not exist.', () => {
-            requireSpy = jasmine.createSpy('require').and.returnValue(false);
-            prepare.__set__({ require: requireSpy });
-
-            SettingJson = new SettingJson(locations.www);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(SettingJson.package).toEqual(false);
-        });
-
-        it('should be called and package equal to true, if settings json does exist.', () => {
-            SettingJson = new SettingJson(locations.www);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(SettingJson.package).toEqual({});
-        });
-
-        it('should be equal to false, when no flag is set.', () => {
-            // mock options data
-            options = { options: { argv: [] } };
-
-            SettingJson = new SettingJson(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(SettingJson.package.isRelease).toEqual(false);
-        });
-
-        it('should be equal to false, when debug flag is set.', () => {
-            // mock options data
-            options = { options: { debug: true, argv: [] } };
-
-            SettingJson = new SettingJson(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(SettingJson.package.isRelease).toEqual(false);
-        });
-
-        it('should be equal to true, when release flag is set.', () => {
-            // mock options data
-            options = { options: { release: true, argv: [] } };
-
-            SettingJson = new SettingJson(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(SettingJson.package.isRelease).toEqual(true);
-        });
-
-        it('should write provided data, when no flag is set.', () => {
-            let writeFileSyncSpy;
-            writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            prepare.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
-            options = { options: { argv: [] } };
-
-            SettingJson = new SettingJson(locations.www).configure(options.options).write();
-
-            expect(writeFileSyncSpy).toHaveBeenCalled();
-
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
-
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":false}');
-
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
-        });
-
-        it('should write provided data, when debug flag is set.', () => {
-            let writeFileSyncSpy;
-            writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            prepare.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
-            options = { options: { debug: true, argv: [] } };
-
-            SettingJson = new SettingJson(locations.www).configure(options.options).write();
-
-            expect(writeFileSyncSpy).toHaveBeenCalled();
-
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
-
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":false}');
-
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
-        });
-
-        it('should write provided data.', () => {
-            let writeFileSyncSpy;
-            writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            prepare.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
-            options = { options: { release: true, argv: [] } };
-
-            SettingJson = new SettingJson(locations.www).configure(options.options).write();
-
-            expect(writeFileSyncSpy).toHaveBeenCalled();
-
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
-
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":true}');
-
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
+            expect(exportPrepare).toBeDefined();
         });
     });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

none

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Refactor prepase.js and increase Code Coverage

### Description
<!-- Describe your changes in detail -->

Created new files for SettingJsonParser, PackageJsonParser and ManifestJsonParser classes. Added Unit Tests for the SettingJsonParser, PackageJsonParser and ManifestJsonParser class and increased prepare.js Code Coverage

### Testing
<!-- Please describe in detail how you tested your changes. -->

npm t

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
