### PR TITLE
Add tests to Api.spec.js

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -54,7 +54,7 @@ class Api {
         this.platform = 'electron';
 
         // MyApp/platforms/electron
-        this.root = path.resolve(__dirname, '..');
+        this.root = platformRootDir || path.resolve(__dirname, '..');
         this.events = setupEvents(events);
         this.parser = new Parser(this.root);
         this.handler = require('./handler');

--- a/bin/templates/cordova/handler.js
+++ b/bin/templates/cordova/handler.js
@@ -67,6 +67,7 @@ module.exports = {
             fs.writeFileSync(moduleDestination, scriptContent, 'utf-8');
         },
         uninstall: (jsModule, www_dir, plugin_id) => {
+            fs.removeSync(path.join(www_dir, 'plugins', plugin_id));
             const pluginRelativePath = path.join('plugins', plugin_id, jsModule.src);
             // common.removeFileAndParents(www_dir, pluginRelativePath);
             events.emit('verbose', `js-module uninstall called : ${pluginRelativePath}`);

--- a/tests/spec/fixtures/testapp/config.xml
+++ b/tests/spec/fixtures/testapp/config.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="whatever" version="1.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>HelloWorld</name>
+    <description>
+        A sample Apache Cordova application.
+    </description>
+    <author email="dev@cordova.com" href="http://cordova.io">
+        Cordova Team
+    </author>
+    <license>Apache 2.0 License</license>
+    <preference name="Orientation" value="portrait" />
+    <content src="index.html" main="index.js" />
+    <plugin name="cordova-plugin-whitelist" spec="1" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <allow-intent href="tel:*" />
+    <allow-intent href="sms:*" />
+    <allow-intent href="mailto:*" />
+    <allow-intent href="geo:*" />
+    <platform name="android">
+        <allow-intent href="market:*" />
+    </platform>
+    <platform name="ios">
+        <allow-intent href="itms:*" />
+        <allow-intent href="itms-apps:*" />
+    </platform>
+    <icon src="res/electron/cordova.png"  width="16" height="16"/>
+    <platform name="electron">
+        <icon src="res/electron/cordova.png"/>
+        <icon src="res/electron/cordova@1.5.png" />
+        <icon src="res/electron/cordova@2.png" />
+        <icon src="res/electron/cordova@3.png" />
+        <icon src="res/electron/cordova@4.png" />
+        <icon src="res/electron/cordova@8.png" />
+        <icon src="res/electron/cordova@16.png" />
+        <icon src="res/electron/cordova_512.png" target="installer" />
+    </platform>
+    <engine name="electron" spec="github:apache/cordova-electron" />
+</widget>

--- a/tests/spec/fixtures/testplugin/src/electron/sample.json
+++ b/tests/spec/fixtures/testplugin/src/electron/sample.json
@@ -1,0 +1,3 @@
+{
+  "title" : "sample"
+}

--- a/tests/spec/fixtures/testplugin/www/plugin.js
+++ b/tests/spec/fixtures/testplugin/www/plugin.js
@@ -1,0 +1,26 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+class TestPlugin {
+
+}
+
+module.exports = new TestPlugin();

--- a/tests/spec/unit/handler.spec.js
+++ b/tests/spec/unit/handler.spec.js
@@ -148,7 +148,14 @@ describe('Handler export', () => {
                 const www_dir = 'www';
                 const pluginRelativePath = path.join('plugins', plugin_id, jsModule.src);
 
+                const removeSyncSpy = jasmine.createSpy('writeFileSync');
+                handler.__set__('fs', {
+                    removeSync: removeSyncSpy
+                });
+
                 handler['js-module'].uninstall(jsModule, www_dir, plugin_id);
+
+                expect(removeSyncSpy).toHaveBeenCalled();
 
                 const actual = emitSpy.calls.argsFor(0)[1];
                 const expected = `js-module uninstall called : ${pluginRelativePath}`;


### PR DESCRIPTION
### Platforms affected
cordova-electron

### Motivation and Context
Adding tests to Api.spec.js to improve tests coverage.

### Description
Some files (Api.js and handler.js) are changed accroding to adding tests.

Especially API.js is improved to choose `root` directory in tests. (Same as `cordova-ios`)
If the `root` directory in API.js is fixed to parent directory of `API.js` as 
```
        this.root = path.resolve(__dirname, '..');
```
, files are generated under the `/bin/templates/project` by `API.js`. 
(For example, `electron.json`, `www/cordova_plugins.js` are created by API.js.)

It is not desirable. 
We want to all generated files are under the `/temp` dir.
Therefore `API.js` is changed to
```
        this.root = platformRootDir || path.resolve(__dirname, '..');
```
to use platformRootDir is it is specified. (This is same as `cordova-ios`)


The `tmpDir` is changed as follows in order to be consistent with `create.spec.js`
`../temp` => `../../../temp` 


### Testing
```
npm run test
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
