### PR TITLE
Code Cleanup & Refactor

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -23,7 +23,6 @@
 */
 const path = require('path');
 const fs = require('fs-extra');
-
 const CordovaCommon = require('cordova-common');
 const CordovaLogger = CordovaCommon.CordovaLogger;
 // const ConfigParser = CordovaCommon.ConfigParser;
@@ -95,8 +94,6 @@ class Api {
     }
 
     addPlugin (pluginInfo, installOptions) {
-
-        // console.log(new Error().stack);
         if (!pluginInfo) {
             return Promise.reject(new Error('The parameter is incorrect. The first parameter should be valid PluginInfo instance'));
         }
@@ -183,7 +180,7 @@ class Api {
 
                 this._removeModulesInfo(plugin, targetDir);
                 // Remove stale plugin directory
-                // TODO: this should be done by plugin files uninstaller
+                // @todo this should be done by plugin files uninstaller
                 fs.removeSync(path.resolve(this.root, 'Plugins', plugin.id));
             });
     }
@@ -193,8 +190,7 @@ class Api {
             const installer = this.handler[type];
 
             if (!installer) {
-                console.log('unrecognized type ' + type);
-
+                this.events.emit('warn', `Unrecognized type "${type}"`);
             } else {
                 const wwwDest = options.usePlatformWww ?
                     this.getPlatformInfo().locations.platformWww :
@@ -215,8 +211,7 @@ class Api {
             const installer = this.handler[type];
 
             if (!installer) {
-                console.log(`electron plugin uninstall: unrecognized type, skipping : ${type}`);
-
+                this.events.emit('warn', `electron plugin uninstall: unrecognized type, skipping : ${type}`);
             } else {
                 const wwwDest = options.usePlatformWww ?
                     this.getPlatformInfo().locations.platformWww :
@@ -347,9 +342,7 @@ class Api {
         return require('./lib/check_reqs').run();
     }
 }
-
-// console.log("test-platform:Api:updatePlatform");
-// todo?: create projectInstance and fulfill promise with it.
+// @todo create projectInstance and fulfill promise with it.
 Api.updatePlatform = () => Promise.resolve();
 
 Api.createPlatform = function (dest, config, options, events) {

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -25,7 +25,7 @@ const ManifestJsonParser = require('./ManifestJsonParser');
 const PackageJsonParser = require('./PackageJsonParser');
 const SettingJsonParser = require('./SettingJsonParser');
 
-module.exports.prepare = (cordovaProject, options) => {
+module.exports.prepare = function (cordovaProject, options) {
     // First cleanup current config and merge project's one into own
     const defaultConfigPath = path.join(this.locations.platformRootDir, 'cordova', 'defaults.xml');
     const ownConfigPath = this.locations.configXml;

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -22,7 +22,6 @@ const proc = require('child_process');
 const path = require('path');
 
 module.exports.run = (args) => {
-    // console.log("runOptions : ", args);
     const child = proc.spawn(electron, ['./platforms/electron/www/main.js']);
 
     child.on('close', (code) => {

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -25,9 +25,7 @@ const Api = rewire(path.join(templateDir, 'cordova', 'Api'));
 const tmpDir = path.join(__dirname, '../../../temp');
 const tmpWorkDir = path.join(tmpDir, 'work');
 const apiRequire = Api.__get__('require');
-
 const FIXTURES = path.join(__dirname, '..', 'fixtures');
-
 const pluginFixture = path.join(FIXTURES, 'testplugin');
 const testProjectDir = path.join(tmpDir, 'testapp');
 
@@ -61,7 +59,6 @@ function writeJson (file, json) {
 }
 
 describe('Api class', () => {
-
     fs.removeSync(tmpDir);
     fs.ensureDirSync(tmpWorkDir);
     copyTestProject();
@@ -163,10 +160,6 @@ describe('Api class', () => {
         });
     });
 
-    /**
-     * @todo Add useful tests.
-     */
-
     describe('addPlugin method', () => {
         let logs = {};
         beforeEach(() => {
@@ -266,26 +259,37 @@ describe('Api class', () => {
             }
         ));
 
-        it('unrecognized type plugin', () => api.addPlugin({
-            id: 'unrecognized-plugin',
-            dir: pluginFixture,
-            getPlatformsArray: () => { return ['electron']; },
-            getFilesAndFrameworks: (platform) => { return []; },
-            getAssets: (platform) => {
-                return [{
-                    itemType: 'unrecognized'
-                }];
-            },
-            getJsModules: (platform) => { return []; },
-            getConfigFiles: (platform) => { return []; }
-        }, { }).then(
-            (result) => {
-                expect(result).not.toBeDefined();
-            },
-            (error) => {
-                fail('Unwanted code branch: ' + error);
-            }
-        ));
+        it('unrecognized type plugin', () => {
+            const _events = api.events;
+            const emitSpy = jasmine.createSpy('emit');
+            api.events = {
+                emit: emitSpy
+            };
+
+            return api.addPlugin({
+                id: 'unrecognized-plugin',
+                dir: pluginFixture,
+                getPlatformsArray: () => { return ['electron']; },
+                getFilesAndFrameworks: (platform) => { return []; },
+                getAssets: (platform) => {
+                    return [{
+                        itemType: 'unrecognized'
+                    }];
+                },
+                getJsModules: (platform) => { return []; },
+                getConfigFiles: (platform) => { return []; }
+            }, { }).then(
+                (result) => {
+                    expect(emitSpy.calls.argsFor(0)[1]).toContain('unrecognized');
+                    expect(result).not.toBeDefined();
+                    api.events = _events;
+                },
+                (error) => {
+                    fail('Unwanted code branch: ' + error);
+                    api.events = _events;
+                }
+            );
+        });
 
         it('source-file type plugin', () => api.addPlugin({
             id: 'source-file-plugin',
@@ -489,51 +493,6 @@ describe('Api class', () => {
             }
         ));
 
-    });
-
-    /**
-     * @todo Add useful test or drop and accept coveage from the parent method call (addPlugin & removePlugin).
-     */
-    describe('_getInstaller method', () => {
-        it('should exist', () => {
-            expect(api._getInstaller).toBeDefined();
-        });
-    });
-
-    /**
-     * @todo Add useful test or drop and accept coveage from the parent method call (addPlugin & removePlugin).
-     */
-    describe('_getUninstaller method', () => {
-        it('should exist', () => {
-            expect(api._getUninstaller).toBeDefined();
-        });
-    });
-
-    /**
-     * @todo Add useful test or drop and accept coveage from the parent method call (addPlugin).
-     */
-    describe('_addModulesInfo method', () => {
-        it('should exist', () => {
-            expect(api._addModulesInfo).toBeDefined();
-        });
-    });
-
-    /**
-     * @todo Add useful test or drop and accept coveage from the parent method call (addPlugin & removePlugin).
-     */
-    describe('_writePluginModules method', () => {
-        it('should exist', () => {
-            expect(api._writePluginModules).toBeDefined();
-        });
-    });
-
-    /**
-     * @todo Add useful test or drop and accept coveage from the parent method call (removePlugin).
-     */
-    describe('_removeModulesInfo method', () => {
-        it('should exist', () => {
-            expect(api._removeModulesInfo).toBeDefined();
-        });
     });
 
     describe('updatePlatform method', () => {

--- a/tests/spec/unit/templates/cordova/lib/prepare.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/prepare.spec.js
@@ -138,13 +138,11 @@ describe('Testing prepare.js:', () => {
         it('should generate config.xml from defaults for platform.', () => {
             // Mocking the scope with dummy API;
             Promise.resolve().then(function () {
+                // Create API instance and mock for test case.
                 const api = new Api(null, '', '');
-                this.locations = api.locations;
-                this.events = { emit: emitSpy };
-                this.config = api.config;
-                this.parser = api.parser;
-                this.parser.update_www = () => { return this; };
-                this.parser.update_project = () => { return this; };
+                api.events = { emit: emitSpy };
+                api.parser.update_www = () => { return this; };
+                api.parser.update_project = () => { return this; };
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
                 const ownConfigPathMock = api.locations.configXml;
@@ -165,7 +163,7 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('PackageJsonParser', FakeParser);
                 prepare.__set__('SettingJsonParser', FakeParser);
 
-                prepare.prepare(cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, {}, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(defaultConfigPathMock, ownConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -184,13 +182,11 @@ describe('Testing prepare.js:', () => {
         it('should generate defaults.xml from own config.xml for platform.', () => {
             // Mocking the scope with dummy API;
             Promise.resolve().then(function () {
+                // Create API instance and mock for test case.
                 const api = new Api(null, '', '');
-                this.locations = api.locations;
-                this.events = { emit: emitSpy };
-                this.config = api.config;
-                this.parser = api.parser;
-                this.parser.update_www = () => { return this; };
-                this.parser.update_project = () => { return this; };
+                api.events = { emit: emitSpy };
+                api.parser.update_www = () => { return this; };
+                api.parser.update_project = () => { return this; };
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
                 const ownConfigPathMock = api.locations.configXml;
@@ -211,7 +207,7 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('PackageJsonParser', FakeParser);
                 prepare.__set__('SettingJsonParser', FakeParser);
 
-                prepare.prepare(cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, {}, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(ownConfigPathMock, defaultConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -229,13 +225,11 @@ describe('Testing prepare.js:', () => {
         it('should hit case 3.', () => {
             // Mocking the scope with dummy API;
             Promise.resolve().then(function () {
+                // Create API instance and mock for test case.
                 const api = new Api(null, '', '');
-                this.locations = api.locations;
-                this.events = { emit: emitSpy };
-                this.config = api.config;
-                this.parser = api.parser;
-                this.parser.update_www = () => { return this; };
-                this.parser.update_project = () => { return this; };
+                api.events = { emit: emitSpy };
+                api.parser.update_www = () => { return this; };
+                api.parser.update_project = () => { return this; };
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
                 const ownConfigPathMock = api.locations.configXml;
@@ -257,7 +251,7 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('PackageJsonParser', FakeParser);
                 prepare.__set__('SettingJsonParser', FakeParser);
 
-                prepare.prepare(cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, {}, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(sourceCfgMock.path, ownConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -275,13 +269,11 @@ describe('Testing prepare.js:', () => {
         it('should copy manifest.', () => {
             // Mocking the scope with dummy API;
             Promise.resolve().then(function () {
+                // Create API instance and mock for test case.
                 const api = new Api(null, '', '');
-                this.locations = api.locations;
-                this.events = { emit: emitSpy };
-                this.config = api.config;
-                this.parser = api.parser;
-                this.parser.update_www = () => { return this; };
-                this.parser.update_project = () => { return this; };
+                api.events = { emit: emitSpy };
+                api.parser.update_www = () => { return this; };
+                api.parser.update_project = () => { return this; };
 
                 const srcManifestPathMock = path.join(cordovaProject.locations.www, 'manifest.json');
                 const manifestPathMock = path.join(api.locations.www, 'manifest.json');
@@ -302,7 +294,7 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('PackageJsonParser', FakeParser);
                 prepare.__set__('SettingJsonParser', FakeParser);
 
-                prepare.prepare(cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, {}, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(srcManifestPathMock, manifestPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -320,13 +312,11 @@ describe('Testing prepare.js:', () => {
         it('should create new manifest file.', () => {
             // Mocking the scope with dummy API;
             Promise.resolve().then(function () {
+                // Create API instance and mock for test case.
                 const api = new Api(null, '', '');
-                this.locations = api.locations;
-                this.events = { emit: emitSpy };
-                this.config = api.config;
-                this.parser = api.parser;
-                this.parser.update_www = () => { return this; };
-                this.parser.update_project = () => { return this; };
+                api.events = { emit: emitSpy };
+                api.parser.update_www = () => { return this; };
+                api.parser.update_project = () => { return this; };
 
                 const srcManifestPathMock = path.join(cordovaProject.locations.www, 'manifest.json');
 
@@ -346,7 +336,7 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('PackageJsonParser', FakeParser);
                 prepare.__set__('SettingJsonParser', FakeParser);
 
-                prepare.prepare(cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, {}, api);
 
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();


### PR DESCRIPTION
### Platforms affected
none


### Motivation and Context
- Cleanup before release
- Fixes platform add failure due to lost scoping.

### Description
- Remove stubbed tests in favor for parent method test.
- Removed un-needed comments.
- Refactor to use emit over console log.
- Spy on emit for testing and also remove un-needed printout during testing.
- Fixes lost scoping when prepare is called.

### Testing
- `npm t`
- Platform Add, Build and Run Test
```
npx cordova@nightly create electronTest com.foobar.electronTest electronTest && cd $_
npx cordova@nightly platform add github:erisu/cordova-electron\#test-cleanup
npx cordova@nightly build electron
npx cordova@nightly run electron --nobuild
```

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
