### PR TITLE
Asset Install Fix from Mobilespec Report

### DIFF
--- a/bin/templates/cordova/handler.js
+++ b/bin/templates/cordova/handler.js
@@ -124,12 +124,7 @@ module.exports = {
             const destDir = path.parse(dest).dir;
 
             if (destDir) fs.ensureDirSync(destDir);
-
-            if (fs.statSync(src).isDirectory()) {
-                fs.copySync(src, dest);
-            } else {
-                fs.copySync(src, dest);
-            }
+            fs.copySync(src, dest);
         },
         uninstall: (asset, wwwDest, plugin_id) => {
             fs.removeSync(path.join(wwwDest, asset.target));

--- a/bin/templates/cordova/handler.js
+++ b/bin/templates/cordova/handler.js
@@ -121,9 +121,12 @@ module.exports = {
         install: (asset, plugin_dir, wwwDest) => {
             const src = path.join(plugin_dir, asset.src);
             const dest = path.join(wwwDest, asset.target);
+            const destDir = path.parse(dest).dir;
+
+            if (destDir) fs.ensureDirSync(destDir);
 
             if (fs.statSync(src).isDirectory()) {
-                fs.copySync(src + '/*', dest);
+                fs.copySync(src, dest);
             } else {
                 fs.copySync(src, dest);
             }

--- a/tests/spec/unit/handler.spec.js
+++ b/tests/spec/unit/handler.spec.js
@@ -330,18 +330,19 @@ describe('Handler export', () => {
         const wwwDest = 'dest';
 
         describe('Install', () => {
-            it('if src is a directory, should be called with cp, -Rf', () => {
-                const asset = { itemType: 'asset', src: 'someSrc/ServiceWorker.js', target: 'ServiceWorker.js' };
+            it('should copySync with a directory path.', () => {
+                const asset = {
+                    itemType: 'asset',
+                    src: 'someSrc/ServiceWorker.js',
+                    target: 'ServiceWorker.js'
+                };
 
                 // Spies
-                const copySyncSpy = jasmine.createSpy('copySync').and.returnValue('-Rf');
-                const fsstatMock = { isDirectory: () => true };
-                const statSyncSpy = jasmine.createSpy('statSync').and.returnValue(fsstatMock);
+                const copySyncSpy = jasmine.createSpy('copySync');
                 const ensureDirSyncSpy = jasmine.createSpy('ensureDirSync').and.returnValue(true);
 
                 handler.__set__('fs', {
                     copySync: copySyncSpy,
-                    statSync: statSyncSpy,
                     ensureDirSync: ensureDirSyncSpy
                 });
 
@@ -350,43 +351,25 @@ describe('Handler export', () => {
                 expect(copySyncSpy).toHaveBeenCalledWith(jasmine.any(String), path.join('dest', asset.target));
             });
 
-            it('if src is a directory, should be called with cp, -Rf', () => {
-                const asset = { itemType: 'asset', src: 'someSrc/ServiceWorker.js', target: 'ServiceWorker.js' };
+            it('should call copySync with a file path.', () => {
+                const asset = {
+                    itemType: 'asset',
+                    src: 'someSrc/ServiceWorker.js',
+                    target: 'ServiceWorker.js'
+                };
 
                 // Spies
-                const copySyncSpy = jasmine.createSpy('copySync').and.returnValue('-Rf');
-                const fsstatMock = { isDirectory: () => true };
-                const statSyncSpy = jasmine.createSpy('statSync').and.returnValue(fsstatMock);
+                const copySyncSpy = jasmine.createSpy('copySync');
                 const ensureDirSyncSpy = jasmine.createSpy('ensureDirSync');
 
                 handler.__set__('fs', {
                     copySync: copySyncSpy,
-                    statSync: statSyncSpy,
                     ensureDirSync: ensureDirSyncSpy
                 });
 
                 handler.asset.install(asset, plugin_dir, wwwDest);
                 expect(ensureDirSyncSpy).toHaveBeenCalled();
                 expect(copySyncSpy).toHaveBeenCalledWith(jasmine.any(String), path.join('dest', asset.target));
-            });
-
-            it('if src is not a directory, should be called with cp, -f', () => {
-                const asset = { itemType: 'asset', src: 'someSrc', target: 'ServiceWorker.js' };
-                const cpPath = path.join(plugin_dir, asset.src);
-
-                // Spies
-                const copySyncSpy = jasmine.createSpy('copySync').and.returnValue('-f');
-                const fsstatMock = { isDirectory: () => false };
-                const statSyncSpy = jasmine.createSpy('statSync').and.returnValue(fsstatMock);
-                const ensureDirSyncSpy = jasmine.createSpy('ensureDirSync');
-                handler.__set__('fs', {
-                    copySync: copySyncSpy,
-                    statSync: statSyncSpy,
-                    ensureDirSync: ensureDirSyncSpy
-                });
-
-                handler.asset.install(asset, plugin_dir, wwwDest);
-                expect(copySyncSpy).toHaveBeenCalledWith(cpPath, path.join('dest', asset.target));
             });
         });
 

--- a/tests/spec/unit/handler.spec.js
+++ b/tests/spec/unit/handler.spec.js
@@ -337,12 +337,36 @@ describe('Handler export', () => {
                 const copySyncSpy = jasmine.createSpy('copySync').and.returnValue('-Rf');
                 const fsstatMock = { isDirectory: () => true };
                 const statSyncSpy = jasmine.createSpy('statSync').and.returnValue(fsstatMock);
+                const ensureDirSyncSpy = jasmine.createSpy('ensureDirSync').and.returnValue(true);
+
                 handler.__set__('fs', {
                     copySync: copySyncSpy,
-                    statSync: statSyncSpy
+                    statSync: statSyncSpy,
+                    ensureDirSync: ensureDirSyncSpy
                 });
 
                 handler.asset.install(asset, plugin_dir, wwwDest);
+                expect(ensureDirSyncSpy).toHaveBeenCalled();
+                expect(copySyncSpy).toHaveBeenCalledWith(jasmine.any(String), path.join('dest', asset.target));
+            });
+
+            it('if src is a directory, should be called with cp, -Rf', () => {
+                const asset = { itemType: 'asset', src: 'someSrc/ServiceWorker.js', target: 'ServiceWorker.js' };
+
+                // Spies
+                const copySyncSpy = jasmine.createSpy('copySync').and.returnValue('-Rf');
+                const fsstatMock = { isDirectory: () => true };
+                const statSyncSpy = jasmine.createSpy('statSync').and.returnValue(fsstatMock);
+                const ensureDirSyncSpy = jasmine.createSpy('ensureDirSync');
+
+                handler.__set__('fs', {
+                    copySync: copySyncSpy,
+                    statSync: statSyncSpy,
+                    ensureDirSync: ensureDirSyncSpy
+                });
+
+                handler.asset.install(asset, plugin_dir, wwwDest);
+                expect(ensureDirSyncSpy).toHaveBeenCalled();
                 expect(copySyncSpy).toHaveBeenCalledWith(jasmine.any(String), path.join('dest', asset.target));
             });
 
@@ -354,9 +378,11 @@ describe('Handler export', () => {
                 const copySyncSpy = jasmine.createSpy('copySync').and.returnValue('-f');
                 const fsstatMock = { isDirectory: () => false };
                 const statSyncSpy = jasmine.createSpy('statSync').and.returnValue(fsstatMock);
+                const ensureDirSyncSpy = jasmine.createSpy('ensureDirSync');
                 handler.__set__('fs', {
                     copySync: copySyncSpy,
-                    statSync: statSyncSpy
+                    statSync: statSyncSpy,
+                    ensureDirSync: ensureDirSyncSpy
                 });
 
                 handler.asset.install(asset, plugin_dir, wwwDest);


### PR DESCRIPTION
### Platforms affected
android


### Motivation and Context
Fix the plugin asset install issue detected by mobilespec for release.

### Description
Updated `fs.copySync` with valid arguments and added a `mkdirp` call before `copySync`.

```
Installing "cordova-plugin-test-framework" for electron
Error during processing of action! Attempting to revert...
Failed to install 'cordova-plugin-test-framework': Error: Uh oh!
ENOENT: no such file or directory, stat '/apache/cordova/mobilespec/plugins/cordova-plugin-test-framework/www/assets/*'
    at Object.fs.statSync (fs.js:948:11)
    at Object.statSync (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/graceful-fs/polyfills.js:295:24)
    at checkStats (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/fs-extra/lib/copy-sync/copy-sync.js:171:22)
    at checkPaths (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/fs-extra/lib/copy-sync/copy-sync.js:183:31)
    at Object.copySync (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/fs-extra/lib/copy-sync/copy-sync.js:25:20)
    at Object.install (/apache/cordova/mobilespec/platforms/electron/cordova/handler.js:126:20)
    at /apache/cordova/mobilespec/platforms/electron/cordova/Api.js:199:31
    at ActionStack.process (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/cordova-common/src/ActionStack.js:56:25)
    at Api.addPlugin (/apache/cordova/mobilespec/platforms/electron/cordova/Api.js:127:24)
    at handleInstall (/apache/cordova/cordova-lib/src/plugman/install.js:581:10)
Uh oh!
ENOENT: no such file or directory, stat '/apache/cordova/mobilespec/plugins/cordova-plugin-test-framework/www/assets/*'


Error during processing of action! Attempting to revert...
Failed to install 'cordova-plugin-inappbrowser-tests': Error: Uh oh!
ENOENT: no such file or directory, stat '/apache/cordova/mobilespec/plugins/cordova-plugin-inappbrowser-tests/resources/*'
    at Object.fs.statSync (fs.js:948:11)
    at Object.statSync (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/graceful-fs/polyfills.js:295:24)
    at checkStats (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/fs-extra/lib/copy-sync/copy-sync.js:171:22)
    at checkPaths (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/fs-extra/lib/copy-sync/copy-sync.js:183:31)
    at Object.copySync (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/fs-extra/lib/copy-sync/copy-sync.js:25:20)
    at Object.install (/apache/cordova/mobilespec/platforms/electron/cordova/handler.js:126:20)
    at /apache/cordova/mobilespec/platforms/electron/cordova/Api.js:199:31
    at ActionStack.process (/apache/cordova/mobilespec/platforms/electron/cordova/node_modules/cordova-common/src/ActionStack.js:56:25)
    at Api.addPlugin (/apache/cordova/mobilespec/platforms/electron/cordova/Api.js:127:24)
    at handleInstall (/apache/cordova/cordova-lib/src/plugman/install.js:581:10)
Uh oh!
ENOENT: no such file or directory, stat '/apache/cordova/mobilespec/plugins/cordova-plugin-inappbrowser-tests/resources/*'
```

### Testing
- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
