### PR TITLE
Refactor API tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 .nyc_output
 coverage
 tests
+temp
 
 # CI service configurations
 .travis.yml

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -23,16 +23,10 @@ const rewire = require('rewire');
 const templateDir = path.resolve(__dirname, '..', '..', '..', 'bin', 'templates');
 const Api = rewire(path.join(templateDir, 'cordova', 'Api'));
 const tmpDir = path.join(__dirname, '../../../temp');
-const tmpWorkDir = path.join(tmpDir, 'work');
 const apiRequire = Api.__get__('require');
 const FIXTURES = path.join(__dirname, '..', 'fixtures');
 const pluginFixture = path.join(FIXTURES, 'testplugin');
 const testProjectDir = path.join(tmpDir, 'testapp');
-
-function copyTestProject () {
-    fs.ensureDirSync(tmpDir);
-    fs.copySync(path.resolve(FIXTURES, 'testapp'), path.resolve(tmpDir, 'testapp'));
-}
 
 function dirExists (dir) {
     return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
@@ -59,9 +53,8 @@ function writeJson (file, json) {
 }
 
 describe('Api class', () => {
-    fs.removeSync(tmpDir);
-    fs.ensureDirSync(tmpWorkDir);
-    copyTestProject();
+    fs.ensureDirSync(tmpDir);
+    fs.copySync(path.resolve(FIXTURES, 'testapp'), path.resolve(tmpDir, 'testapp'));
 
     const api = new Api(null, testProjectDir);
     const apiEvents = Api.__get__('selfEvents');
@@ -508,18 +501,18 @@ describe('Api class', () => {
 
     describe('createPlatform method', () => {
         beforeEach(() => {
-            fs.removeSync(tmpWorkDir);
+            fs.removeSync(tmpDir);
         });
 
         afterEach(() => {
-            fs.removeSync(tmpWorkDir);
+            fs.removeSync(tmpDir);
         });
 
         /**
          * @todo improve createPlatform to test actual created platforms.
          */
         it('should export static createPlatform function', () => {
-            return Api.createPlatform(tmpWorkDir).then(
+            return Api.createPlatform(tmpDir).then(
                 (results) => {
                     expect(results.constructor.name).toBe(api.constructor.name);
                 }
@@ -533,7 +526,7 @@ describe('Api class', () => {
                 };
             });
 
-            expect(() => Api.createPlatform(tmpWorkDir)).toThrowError(/createPlatform is not callable from the electron project API/);
+            expect(() => Api.createPlatform(tmpDir)).toThrowError(/createPlatform is not callable from the electron project API/);
 
             Api.__set__('require', apiRequire);
         });


### PR DESCRIPTION
- Remove temp folder after tests
- Add temp folder to .npmignore

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This closes #31.

### Description
<!-- Describe your changes in detail -->

When testing the API's functionality `temp` folder is created. However, after the tests finish it's not deleted. We probably should delete that after we finish testing.

I have refactored the API tests to delete the `temp` folder after tests. Also, I have added the `temp` folder to `.npmignore` just as it is in `.gitignore`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

npm t.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
