### PR TITLE
Update run to work with Cordova CLI prior version 9.x

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -85,6 +85,13 @@ $ cd sampleApp
 $ cordova platform add electron
 ```
 
+_Notice: If using Cordova CLI prior to version 9.x, you will need to use the `cordova-electron` argument instead of `electron` for any command that requires the platform's name. For example:_
+
+```
+$ cordova platform add cordova-electron
+$ cordova run cordova-electron
+```
+
 ### Preview a Project
 
 It is not necessary to build the Electron application for previewing. Since the building process can be slow, it is recommended to pass in the `--no-build` flag to disable the build process when previewing.

--- a/bin/templates/cordova/lib/run.js
+++ b/bin/templates/cordova/lib/run.js
@@ -22,7 +22,8 @@ const proc = require('child_process');
 const path = require('path');
 
 module.exports.run = (args) => {
-    const child = proc.spawn(electron, ['./platforms/electron/www/main.js']);
+    const pathToMain = path.resolve(__dirname, '..', '..', 'www', 'main.js');
+    const child = proc.spawn(electron, [pathToMain]);
 
     child.on('close', (code) => {
         process.exit(code);

--- a/tests/spec/unit/templates/cordova/lib/run.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/run.spec.js
@@ -18,6 +18,7 @@
 */
 
 const rewire = require('rewire');
+const path = require('path');
 const run = rewire('../../../../../../bin/templates/cordova/lib/run');
 
 describe('Run', () => {
@@ -27,6 +28,7 @@ describe('Run', () => {
             const spawnSpy = jasmine.createSpy('spawn');
             const onSpy = jasmine.createSpy('on');
             const exitSpy = jasmine.createSpy('exit');
+            const expectedPathToMain = path.resolve(__dirname, '..', '..', '..', '..', '..', '..', 'bin', 'templates', 'www', 'main.js');
 
             run.__set__('electron', 'electron-require');
             run.__set__('process', {
@@ -41,7 +43,7 @@ describe('Run', () => {
 
             run.run();
 
-            expect(spawnSpy).toHaveBeenCalledWith('electron-require', ['./platforms/electron/www/main.js']);
+            expect(spawnSpy).toHaveBeenCalledWith('electron-require', [expectedPathToMain]);
             expect(onSpy).toHaveBeenCalled();
             expect(exitSpy).not.toHaveBeenCalled();
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Running electron platform with cordova-lib prior 9.x.x breaks. This is because prior to Cordova 9, the electron platform is added to `cordova-electron` folder, but in the `run.js` we have a static path pointing to `./platforms/electron/www/main.js`. Therefore it's unable to locate the `main.js` and results in an error.

### Description
<!-- Describe your changes in detail -->

Changed static string in the `run.js` to more "dynamic" approach using `path.resolve` with `__dirname`. Also, updated tests to test this functionality.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Added and ran electron platform with both `cordova (8.1.2)` and `cordova-nighly (9.0.0)` versions. Also, executed automated tests using:

```
npm t
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
