### PR TITLE
Remove nodeIntegration Warning by Setting Default to False

### DIFF
--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -41,7 +41,8 @@ function createWindow () {
     mainWindow = new BrowserWindow({
         width: 800,
         height: 600,
-        icon: appIcon
+        icon: appIcon,
+        webPreferences: cdvElectronSettings.webPreferences
     });
 
     // and load the index.html of the app.

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,6 +1,6 @@
 {
     "isRelease": false,
     "webPreferences": {
-        "nodeIntegration": true
+        "nodeIntegration": false
     }
 }

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,3 +1,6 @@
 {
-    "isRelease": false
+    "isRelease": false,
+    "webPreferences": {
+        "nodeIntegration": true
+    }
 }


### PR DESCRIPTION
### Platforms affected
electron

### Motivation and Context
Remove Electron Deprecation Warnings.

When previewing debug builds with dev tools open, Electron displays a console warning:

```
Electron Deprecation Warning (nodeIntegration default change) This window has node integration enabled by default. In Electron 5.0.0, node integration will be disabled by default. To prepare for this change, set {nodeIntegration: true} in the webPreferences for this window, or ensure that this window does not rely on node integration and set {nodeIntegration: false}.
```

### Description
This PR adds `{ nodeIntegration: false }` as the default value.

### Testing
- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
