### PR TITLE
Support User Defined Electron Settings

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -31,12 +31,13 @@ Electron is a framework that uses web technologies (HTML, CSS, and JS) to build 
     - [Preview a Project](#preview-a-project)
     - [Build a Project](#build-a-project)
   - [Customizing the Application's Icon](#customizing-the-applications-icon)
-  - [Customizing the Application's Main Process](#customizing-the-applications-main-process)
-    - [Window Appearance (BrowserWindow)](#window-appearance-browserwindow)
-      - [How to set the window default size?](#how-to-set-the-window-default-size)
-      - [How to make the window not resizable?](#how-to-make-the-window-not-resizable)
-      - [How to make my window fullscreen?](#how-to-make-my-window-fullscreen)
-    - [DevTools](#devtools)
+  - [Customizing the Application's Window Options](#customizing-the-applications-window-options)
+    - [How to set the window's default size?](#how-to-set-the-windows-default-size)
+    - [How to make the window not resizable?](#how-to-make-the-window-not-resizable)
+    - [How to make my window fullscreen?](#how-to-make-my-window-fullscreen)
+    - [How to support Node.js and Electron APIs?](#how-to-support-nodejs-and-electron-apis)
+  - [Customizing the Electron's Main Process](#customizing-the-electrons-main-process)
+  - [DevTools](#devtools)
   - [Build Configurations](#build-configurations)
     - [Default Build Configurations](#default-build-configurations)
     - [Customizing Build Configurations](#customizing-build-configurations)
@@ -94,10 +95,10 @@ $ cordova run cordova-electron
 
 ### Preview a Project
 
-It is not necessary to build the Electron application for previewing. Since the building process can be slow, it is recommended to pass in the `--no-build` flag to disable the build process when previewing.
+It is not necessary to build the Electron application for previewing. Since the building process can be slow, it is recommended to pass in the `--nobuild` flag to disable the build process when previewing.
 
 ```
-$ cordova run electron --no-build
+$ cordova run electron --nobuild
 ```
 
 ### Build a Project
@@ -158,48 +159,101 @@ If you want to support displays with different DPI densities at the same time, y
 </platform>
 ```
 
-## Customizing the Application's Main Process
+## Customizing the Application's Window Options
 
-In the `{PROJECT_ROOT_DIR}/platform/electron/platform_www/` directory, the file `cdv-electron-main.js` defines the application's main process. We can customize the application's window appearance as well as defining or enabling additional features in this file.
+Electron provides many options to manipulate the [`BrowserWindow`](https://electronjs.org/docs/api/browser-window). This section will cover how to configure a few basic options. For a full list of options, please see the [Electron's Docs - BrowserWindow Options](https://electronjs.org/docs/api/browser-window#new-browserwindowoptions).
 
-### Window Appearance (BrowserWindow)
+Working with a Cordova project, it is recommended to create an Electron settings file within the project's root directory, and set its the relative path in the preference option `ElectronSettingsFilePath`, in the `config.xml` file.
 
-Electron provides many options to manipulate the BrowserWindow. This section covers only a few basic options. For a full list of options, please see the [Electron's Docs - BrowserWindow Options](https://electronjs.org/docs/api/browser-window#new-browserwindowoptions).
+**Example `config.xml`:**
 
-Electron provides many optional options that can manipulate the BrowserWindow. This section will cover a few of these options that many uses. A full list of these options can be found on the 
-
-#### How to set the window default size?
-
-Using the `width` and `height` option, you can define starting default window size.
-
-```
-mainWindow = new BrowserWindow({
-  width: 800,
-  height: 600
-});
+```xml
+<platform name="electron">
+    <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
+</platform>
 ```
 
-#### How to make the window not resizable?
+To override or set any BrowserWindow options, in this file the options are added to the  `browserWindow` property.
 
-Using the `resizable` flag option, you can disable the user's ability to resize your application's window.
+**Example `res/electron/settings.json`:**
 
-```
-mainWindow = new BrowserWindow({ resizable: false });
-```
-
-#### How to make my window fullscreen?
-
-Using the `fullscreen` flag option, you can force the application to launch in fullscreen.
-
-```
-mainWindow = new BrowserWindow({ fullscreen: true });
+```json
+{
+    "browserWindow": { ... }
+}
 ```
 
-### DevTools
+### How to set the window's default size?
+
+By default, the `width` is set to **800** and the `height` set to **600**. This can be overridden by setting the `width` and `height` property.
+
+**Example:**
+
+```json
+{
+    "browserWindow": {
+        "width": 1024,
+        "height": 768
+    }
+}
+```
+
+### How to make the window not resizable?
+
+Setting the `resizable` flag property, you can disable the user's ability to resize your application's window.
+
+**Example:**
+
+```json
+{
+    "browserWindow": {
+        "resizable": false
+    }
+}
+```
+
+### How to make my window fullscreen?
+
+Using the `fullscreen` flag property, you can force the application to launch in fullscreen.
+
+**Example:**
+
+```json
+{
+    "browserWindow": {
+        "fullscreen": true
+    }
+}
+```
+
+### How to support Node.js and Electron APIs?
+
+Set the `nodeIntegration` flag property to true.  By default, this property flag is set to false to support popular libraries that insert symbols with the same names that Node.js and Electron already uses.
+
+> You can read more about this at Electron docs: [I can not use jQuery/RequireJS/Meteor/AngularJS in Electron
+](https://electronjs.org/docs/faq#i-can-not-use-jqueryrequirejsmeteorangularjs-in-electron).
+
+**Example:**
+
+```json
+{
+    "browserWindow": {
+        "nodeIntegration": true
+    }
+}
+```
+
+## Customizing the Electron's Main Process
+
+If it is necessary to customize the Electron's main process beyond the scope of the Electron's configuration settings, chances can be added directly to the `cdv-electron-main.js` file located in `{PROJECT_ROOT_DIR}/platform/electron/platform_www/`. This is the application's main process.
+
+> :warning:  However, it is not recommended to modify this file as the upgrade process for `cordova-electron` is to remove the old platform before adding the new version.
+
+## DevTools
 
 The `--release` and `--debug` flags control the visibility of the DevTools. DevTools are shown by default on **Debug Builds** (`without a flag` or with `--debug`). If you want to hide the DevTools pass in the `--release` flag when building or running the application.
 
-_Note: DevTools still can be closed or opened manually._
+> Note: DevTools can be closed or opened manually with the debug build.
 
 ## Build Configurations
 
@@ -326,7 +380,7 @@ The `arch` property is an array list of architectures that each package is built
 * arm64
 
 
-The example above will generate a `x64` `dmg` package.
+The example above will generate an `x64` `dmg` package.
 
 ```
 {
@@ -477,6 +531,6 @@ There are not signing requirements for Linux builds.
 
 All browser-based plugins are usable with the Electron platform.
 
-When adding a plugin, if the plugin supports both the `electron` and `browser` platform, the `electron` portion will be used. If the plugin misses `electron`, but contains the `browser` implementation, it will fall back on the `browser` implementation.
+When adding a plugin, if the plugin supports both the `electron` and `browser` platform, the `electron` portion will be used. If the plugin misses `electron` but contains the `browser` implementation, it will fall back on the `browser` implementation.
 
-Internally, Electron is using Chromium (Chrome) as its web view. Some plugins may have conditions written specifically for each different browser. In this case, it may affect the behavior from what is intended. Since Electron may support feature that the browser does not, these plugins would possibly need to be updated for the `electron` platform.
+Internally, Electron is using Chromium (Chrome) as its web view. Some plugins may have conditions written specifically for each different browser. In this case, it may affect the behavior of what is intended. Since Electron may support feature that the browser does not, these plugins would possibly need to be updated for the `electron` platform.

--- a/bin/templates/cordova/lib/SettingJsonParser.js
+++ b/bin/templates/cordova/lib/SettingJsonParser.js
@@ -35,7 +35,7 @@ class SettingJsonParser {
         }
 
         if (config) {
-            this.package.isRelease = (typeof (config.release) !== 'undefined') ? config.release : false;
+            this.package.browserWindow.webPreferences.devTools = !config.release;
         }
 
         return this;

--- a/bin/templates/cordova/lib/SettingJsonParser.js
+++ b/bin/templates/cordova/lib/SettingJsonParser.js
@@ -19,6 +19,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const { deepMerge } = require('./util');
 
 class SettingJsonParser {
     constructor (wwwDir) {
@@ -26,7 +27,13 @@ class SettingJsonParser {
         this.package = require(this.path);
     }
 
-    configure (config) {
+    configure (config, userElectronSettingsPath) {
+        // Apply user settings ontop of defaults.
+        if (userElectronSettingsPath) {
+            const userElectronSettings = require(userElectronSettingsPath);
+            this.package = deepMerge(this.package, userElectronSettings);
+        }
+
         if (config) {
             this.package.isRelease = (typeof (config.release) !== 'undefined') ? config.release : false;
         }

--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -20,20 +20,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const events = require('cordova-common').events;
-
-function deepMerge (mergeTo, mergeWith) {
-    for (const property in mergeWith) {
-        if (Object.prototype.toString.call(mergeWith[property]) === '[object Object]') {
-            mergeTo[property] = deepMerge((mergeTo[property] || {}), mergeWith[property]);
-        } else if (Object.prototype.toString.call(mergeWith[property]) === '[object Array]') {
-            mergeTo[property] = [].concat((mergeTo[property] || []), mergeWith[property]);
-        } else {
-            mergeTo[property] = mergeWith[property];
-        }
-    }
-
-    return mergeTo;
-}
+const { deepMerge } = require('./util');
 
 const PLATFORM_MAPPING = {
     linux: 'linux',

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -75,9 +75,14 @@ module.exports.prepare = function (cordovaProject, options) {
         .configure(this.config)
         .write();
 
+    const userElectronSettings = cordovaProject.projectConfig.getPlatformPreference('ElectronSettingsFilePath', 'electron');
+    const userElectronSettingsPath = userElectronSettings && fs.existsSync(path.resolve(cordovaProject.root, userElectronSettings))
+        ? path.resolve(cordovaProject.root, userElectronSettings)
+        : undefined;
+
     // update Electron settings in .json file
     (new SettingJsonParser(this.locations.www))
-        .configure(options.options)
+        .configure(options.options, userElectronSettingsPath)
         .write();
 
     // update project according to config.xml changes.

--- a/bin/templates/cordova/lib/util.js
+++ b/bin/templates/cordova/lib/util.js
@@ -1,0 +1,13 @@
+module.exports.deepMerge = function (mergeTo, mergeWith) {
+    for (const property in mergeWith) {
+        if (Object.prototype.toString.call(mergeWith[property]) === '[object Object]') {
+            mergeTo[property] = module.exports.deepMerge((mergeTo[property] || {}), mergeWith[property]);
+        } else if (Object.prototype.toString.call(mergeWith[property]) === '[object Array]') {
+            mergeTo[property] = [].concat((mergeTo[property] || []), mergeWith[property]);
+        } else {
+            mergeTo[property] = mergeWith[property];
+        }
+    }
+
+    return mergeTo;
+};

--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -49,7 +49,7 @@ function createWindow () {
     });
 
     // Open the DevTools.
-    if (!cdvElectronSettings.isRelease) {
+    if (!cdvElectronSettings.browserWindow.webPreferences.devTools) {
         mainWindow.webContents.openDevTools();
     }
 

--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -38,12 +38,8 @@ function createWindow () {
         appIcon = `${__dirname}/img/logo.png`;
     }
 
-    mainWindow = new BrowserWindow({
-        width: 800,
-        height: 600,
-        icon: appIcon,
-        webPreferences: cdvElectronSettings.webPreferences
-    });
+    const browserWindowOpts = Object.assign({}, cdvElectronSettings.browserWindow, { icon: appIcon });
+    mainWindow = new BrowserWindow(browserWindowOpts);
 
     // and load the index.html of the app.
     // TODO: possibly get this data from config.xml

--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -49,7 +49,7 @@ function createWindow () {
     });
 
     // Open the DevTools.
-    if (!cdvElectronSettings.browserWindow.webPreferences.devTools) {
+    if (cdvElectronSettings.browserWindow.webPreferences.devTools) {
         mainWindow.webContents.openDevTools();
     }
 

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,9 +1,10 @@
 {
     "browserWindow": {
+        "height": 600,
         "webPreferences":{
-            "devTools": true
+            "devTools": true,
+            "nodeIntegration": false
         },
-        "width": 800,
-        "height": 600
+        "width": 800
     }
 }

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,11 +1,9 @@
 {
-    "isRelease": false,
     "browserWindow": {
-        "devTools": false,
+        "webPreferences":{
+            "devTools": true
+        },
         "width": 800,
-        "height": 600,
-        "webPreferences": {
-            "nodeIntegration": false
-        }
+        "height": 600
     }
 }

--- a/bin/templates/project/cdv-electron-settings.json
+++ b/bin/templates/project/cdv-electron-settings.json
@@ -1,6 +1,11 @@
 {
     "isRelease": false,
-    "webPreferences": {
-        "nodeIntegration": false
+    "browserWindow": {
+        "devTools": false,
+        "width": 800,
+        "height": 600,
+        "webPreferences": {
+            "nodeIntegration": false
+        }
     }
 }

--- a/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
@@ -152,6 +152,60 @@ describe('Testing SettingJsonParser.js:', () => {
             expect(settingsFormat).toEqual('utf8');
         });
 
+        it('should load users blank settings and merge on default.', () => {
+            options = { options: { debug: true, argv: [] } };
+
+            SettingJsonParser.__set__('require', (file) => {
+                if (file === 'LOAD_MY_FAKE_DATA') return {};
+
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        isRelease: false,
+                        webPreferences: {
+                            nodeIntegration: true
+                        }
+                    };
+                }
+
+                return require(file);
+            });
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
+
+            expect(settingJsonParser.package.webPreferences.nodeIntegration).toBe(true);
+        });
+
+        it('should load users override settings and merge on default.', () => {
+            options = { options: { debug: true, argv: [] } };
+
+            SettingJsonParser.__set__('require', (file) => {
+                if (file === 'LOAD_MY_FAKE_DATA') {
+                    return {
+                        webPreferences: {
+                            nodeIntegration: false
+                        }
+                    };
+                }
+
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        isRelease: false,
+                        webPreferences: {
+                            nodeIntegration: true
+                        }
+                    };
+                }
+
+                return require(file);
+            });
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
+
+            expect(settingJsonParser.package.webPreferences.nodeIntegration).toBe(false);
+        });
+
         it('should write provided data.', () => {
             const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
             settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });

--- a/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
@@ -67,92 +67,96 @@ describe('Testing SettingJsonParser.js:', () => {
             expect(settingJsonParser.package).toEqual({});
         });
 
-        it('should be equal to undefined, when config file is undefined.', () => {
-            // mock options data
-            options = { options: { argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(undefined);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(undefined);
-        });
-
-        it('should be equal to false, when no flag is set.', () => {
-            // mock options data
-            options = { options: { argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(false);
-        });
-
-        it('should be equal to false, when debug flag is set.', () => {
-            // mock options data
-            options = { options: { debug: true, argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
-
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(false);
-        });
-
-        it('should be equal to true, when release flag is set.', () => {
-            // mock options data
+        it('should use default when users settings files does not exist, but set devTools value from options', () => {
             options = { options: { release: true, argv: [] } };
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options);
+            SettingJsonParser.__set__('require', (file) => {
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
+                        }
+                    };
+                }
 
-            expect(requireSpy).toHaveBeenCalled();
-            expect(settingJsonParser.package.isRelease).toEqual(true);
+                return require(file);
+            });
+
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, false);
+
+            expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(false);
+            expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(true);
         });
 
-        it('should write provided data, when no flag is set.', () => {
-            let writeFileSyncSpy;
-            writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
+        it('should use default when users settings files does not exist.', () => {
+            options = {};
 
-            options = { options: { argv: [] } };
+            SettingJsonParser.__set__('require', (file) => {
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
+                        }
+                    };
+                }
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+                return require(file);
+            });
 
-            expect(writeFileSyncSpy).toHaveBeenCalled();
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, false);
 
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
-
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":false}');
-
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
+            expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(true);
+            expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(true);
         });
 
-        it('should write provided data, when debug flag is set.', () => {
-            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
+        it('should load users override settings and merge on default, but set devTools value from options.', () => {
             options = { options: { debug: true, argv: [] } };
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+            SettingJsonParser.__set__('require', (file) => {
+                if (file === 'LOAD_MY_FAKE_DATA') {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: false,
+                                nodeIntegration: false
+                            }
+                        }
+                    };
+                }
 
-            expect(writeFileSyncSpy).toHaveBeenCalled();
+                // return defaults
+                if (file.includes('cdv-electron-settings.json')) {
+                    return {
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
+                        }
+                    };
+                }
 
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
+                return require(file);
+            });
 
-            // get settings json file content and remove white spaces
-            let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
-            settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":false}');
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
 
-            const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
-            expect(settingsFormat).toEqual('utf8');
+            expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(true);
+            expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(false);
+
         });
 
-        it('should load users blank settings and merge on default.', () => {
+        it('should write provided data.', () => {
+            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
+            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
             options = { options: { debug: true, argv: [] } };
 
             SettingJsonParser.__set__('require', (file) => {
@@ -161,9 +165,11 @@ describe('Testing SettingJsonParser.js:', () => {
                 // return defaults
                 if (file.includes('cdv-electron-settings.json')) {
                     return {
-                        isRelease: false,
-                        webPreferences: {
-                            nodeIntegration: true
+                        browserWindow: {
+                            webPreferences: {
+                                devTools: true,
+                                nodeIntegration: true
+                            }
                         }
                     };
                 }
@@ -171,58 +177,14 @@ describe('Testing SettingJsonParser.js:', () => {
                 return require(file);
             });
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
-
-            expect(settingJsonParser.package.webPreferences.nodeIntegration).toBe(true);
-        });
-
-        it('should load users override settings and merge on default.', () => {
-            options = { options: { debug: true, argv: [] } };
-
-            SettingJsonParser.__set__('require', (file) => {
-                if (file === 'LOAD_MY_FAKE_DATA') {
-                    return {
-                        webPreferences: {
-                            nodeIntegration: false
-                        }
-                    };
-                }
-
-                // return defaults
-                if (file.includes('cdv-electron-settings.json')) {
-                    return {
-                        isRelease: false,
-                        webPreferences: {
-                            nodeIntegration: true
-                        }
-                    };
-                }
-
-                return require(file);
-            });
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
-
-            expect(settingJsonParser.package.webPreferences.nodeIntegration).toBe(false);
-        });
-
-        it('should write provided data.', () => {
-            const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
-            settingJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });
-
-            options = { options: { release: true, argv: [] } };
-
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options).write();
+            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA').write();
 
             expect(writeFileSyncSpy).toHaveBeenCalled();
-
-            const settingsPath = writeFileSyncSpy.calls.argsFor(0)[0];
-            expect(settingsPath).toEqual(path.join('mock', 'www', 'cdv-electron-settings.json'));
 
             // get settings json file content and remove white spaces
             let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
             settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual('{"isRelease":true}');
+            expect(settingsFile).toEqual(`{"browserWindow":{"webPreferences":{"devTools":true,"nodeIntegration":true}}}`);
 
             const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
             expect(settingsFormat).toEqual('utf8');

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -29,24 +29,6 @@ describe('Testing build.js:', () => {
         build = rewire('../../../../../../bin/templates/cordova/lib/build');
     });
 
-    describe('deepMerge method', () => {
-        it('should deep merge objects and arrays.', () => {
-            const deepMerge = build.__get__('deepMerge');
-
-            const mergeTo = { foo: 'bar', abc: [ 1, 2, 3 ] };
-            const mergeWith = { food: 'candy', abc: [ 5 ] };
-
-            const actual = deepMerge(mergeTo, mergeWith);
-            const expected = {
-                foo: 'bar',
-                food: 'candy',
-                abc: [ 1, 2, 3, 5 ]
-            };
-
-            expect(actual).toEqual(expected);
-        });
-    });
-
     describe('Build class', () => {
         let ElectronBuilder;
         let electronBuilder;

--- a/tests/spec/unit/templates/cordova/lib/util.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/util.spec.js
@@ -1,0 +1,38 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const util = require('../../../../../../bin/templates/cordova/lib/util');
+
+describe('Testing util.js:', () => {
+    describe('deepMerge method', () => {
+        it('should deep merge objects and arrays.', () => {
+            const mergeTo = { foo: 'bar', abc: [ 1, 2, 3 ] };
+            const mergeWith = { food: 'candy', abc: [ 5 ] };
+
+            const actual = util.deepMerge(mergeTo, mergeWith);
+            const expected = {
+                foo: 'bar',
+                food: 'candy',
+                abc: [ 1, 2, 3, 5 ]
+            };
+
+            expect(actual).toEqual(expected);
+        });
+    });
+});


### PR DESCRIPTION
### Platforms affected
electron

### Motivation and Context
Provide a way to allow users to modify the Cordova Electron Settings file.

### Description
This PR allows users to create a file that will be merged with the defaults and and written to the staging area.

The user can create and place the file anywhere from within the project directory and then provides the link within `config.xml`

Example:

```xml
<platform name="electron">
    <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
</platform>
```

This file does not have any filename restrictions.
It will be fetched and merged on top of the Cordova defaults.

Example:
Cordova Defaults are:
```json
{
    "browserWindow": {
        "width": 800,
        "height": 600,
        "webPreferences": {
            "devTools": false,
            "nodeIntegration": false
         }
    }
}
```
If the user would like to support Node.JS and Electron APIs, the developer can create a new file with

```json
{
    "browserWindow": {
        "webPreferences": {
            "nodeIntegration": true
         }
    }
}
```

### Testing
- `npm t`
- Travis CI
- Below Use Cases

**Test Case Nightly**

```
npx cordova@nightly create e9x com.foobar.e9x e9x && $_
npx cordova@nightly platform add github:erisu/cordova-electron\#support-user-defined-electron-settings

npx cordova@nightly run electron --nobuild
npx cordova@nightly run electron --nobuild --release
npx cordova@nightly run electron --nobuild --debug
```

**CDVEletronSettings Override Test Case 1**

Created `res/electron/settings.json` with content:
```json
{
    "browserWindow": {
        "width": 1024,
        "height": 768
    }
}
```

Updated `config.xml` with content:

```xml
<platform name="electron">
    <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
</platform>
```
```
$ npx cordova@nightly run electron --nobuild
```
**Expected:** Larger Size and Open devTools
**Result:** Pass

**CDVEletronSettings Override Test Case 2**

Created `res/electron/settings.json` with content:

```json
{
  "browserWindow": {
    "height": 768,
    "webPreferences": {
      "devTools": false,
      "nodeIntegration": null
    },
    "width": 1024
  }
}
```

Updated `config.xml` with content:

```xml
<platform name="electron">
    <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
</platform>
```

```
$ npx cordova@nightly run electron --nobuild
```

**Expected:** Large Size, nodeIntegration Warning, devTools open as command overrides this setting.
**Result:** Pass

```
npx cordova@nightly build electron
npx cordova@nightly build electron --release
npx cordova@nightly build electron --debug
npx cordova@nightly platform rm electron
```

**Test Case Latest (8.x)**
```
npx cordova@latest create e8x com.foobar.e8x e8x && $_
npx cordova@latest platform add github:erisu/cordova-electron\#support-user-defined-electron-settings

npx cordova@latest run cordova-electron --nobuild
npx cordova@latest run cordova-electron --nobuild --release
npx cordova@latest run cordova-electron --nobuild --debug
```

**CDVEletronSettings Override Test Case 1**

Created `res/electron/settings.json` with content:
```json
{
    "browserWindow": {
        "width": 1024,
        "height": 768
    }
}
```

Updated `config.xml` with content:

```xml
<platform name="electron">
    <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
</platform>
```

```
$ npx cordova@latest run cordova-electron --nobuild
```

**Expected:** Larger Size and Open devTools
**Result:** Pass

**CDVEletronSettings Override Test Case 2**

Created `res/electron/settings.json` with content:

```json
{
  "browserWindow": {
    "height": 768,
    "webPreferences": {
      "devTools": false,
      "nodeIntegration": null
    },
    "width": 1024
  }
}
```

Updated `config.xml` with content:

```xml
<platform name="electron">
    <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
</platform>
```


```
$ npx cordova@latest run cordova-electron --nobuild
```

**Expected:** Large Size, nodeIntegration Warning, devTools open as command overrides this setting.
**Result:** Pass

```
npx cordova@latest build cordova-electron
npx cordova@latest build cordova-electron --release
npx cordova@latest build cordova-electron --debug
npx cordova@latest platform rm cordova-electron
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
