### PR TITLE
Added Missing License Header to util.js

### DIFF
--- a/bin/templates/cordova/lib/util.js
+++ b/bin/templates/cordova/lib/util.js
@@ -1,3 +1,22 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
 module.exports.deepMerge = function (mergeTo, mergeWith) {
     for (const property in mergeWith) {
         if (Object.prototype.toString.call(mergeWith[property]) === '[object Object]') {


### PR DESCRIPTION
### Platforms affected
electron

### Motivation and Context
Cordova Electron 1.0.2 patch release

### Description
Added missing Apache license header to util.js

### Testing
none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
