### PR TITLE
Remove temp dir after create.spec.js tests

### DIFF
--- a/tests/spec/unit/create.spec.js
+++ b/tests/spec/unit/create.spec.js
@@ -142,5 +142,8 @@ describe('create', () => {
         create.createProject(tmpDir, projectname, projectid, projectname);
 
         expect(emitSpy).toHaveBeenCalledWith('error', 'Please make sure you meet the software requirements in order to build a cordova electron project');
+
+        // clean-up
+        fs.removeSync(tmpDir);
     });
 });


### PR DESCRIPTION
### Platforms affected

electron

### Motivation and Context



After running tests `create.spec.js` leaves a `temp` directory.

### Description


Delete `temp` directory after tests finish.

### Testing


`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary