### PR TITLE
Update the config.xml path in the XHR load eventListener

### DIFF
--- a/cordova-js-src/confighelper.js
+++ b/cordova-js-src/confighelper.js
@@ -64,7 +64,7 @@ function readConfig (success, error) {
     xhr.addEventListener('load', xhrStatusChangeHandler);
 
     try {
-        xhr.open('get', '/config.xml', true);
+        xhr.open('get', 'config.xml', true);
         xhr.send();
     } catch (e) {
         fail('[Electron][cordova.js][readConfig] Could not XHR config.xml: ' + JSON.stringify(e));

--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -882,7 +882,7 @@ function readConfig (success, error) {
     xhr.addEventListener('load', xhrStatusChangeHandler);
 
     try {
-        xhr.open('get', '/config.xml', true);
+        xhr.open('get', 'config.xml', true);
         xhr.send();
     } catch (e) {
         fail('[Electron][cordova.js][readConfig] Could not XHR config.xml: ' + JSON.stringify(e));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

I am using macOS Mojave, but I think this should affect Windows and Linux as well. This is a fix for the Electron platform in Cordova.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This makes the configuration settings in config.xml work when targeting the Electron platform when running Cordova.

I am specifically working with the [Splashscreen Cordova plugin](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/) and the settings were not loading when Cordova targeting Electron, like this: 

cordova run electron --livereload

The settings I tried to pull in is in the root of my project in config.xml:

    <platform name="electron">
        <icon src="assets/imgs/icon.png" />
        <splash src="assets/imgs/splash.png" />
        <preference name="SplashScreen" value="assets/imgs/splash.png" />
        <preference name="SplashScreenWidth" value="2732" />
        <preference name="SplashScreenHeight" value="2732" />
    </platform>

### Description
<!-- Describe your changes in detail -->

I changed cordova-js-src/confighelper.js and cordova-lib/cordova.js to load config.xml from the relative location and not the root. (I just removed the "/" in front of config.xml.)

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran all tests.

### Checklist

- [Yes ] I've run the tests to see all new and existing tests pass
- [N/A] I added automated test coverage as appropriate for this change
- [N/A] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [N/A] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [N/A] I've updated the documentation if necessary
