### PR TITLE
Append installer icon to user build settings

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -98,6 +98,10 @@ class ElectronBuilder {
             target: []
         };
 
+        // Apply custom app installer icon when the user is using a custom build configuration
+        // eslint-disable-next-line no-template-curly-in-string
+        userBuildSettings.config[platform].icon = '${APP_INSTALLER_ICON}';
+
         // Only macOS has a build type distinction. (development or distribution)
         // eslint-disable-next-line no-template-curly-in-string
         if (platform === 'mac') userBuildSettings.config[platform].type = '${BUILD_TYPE}';

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -225,13 +225,15 @@ describe('Testing build.js:', () => {
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
                 ],
-                type: '${BUILD_TYPE}'
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
             };
             const expectedLinux = {
                 target: [
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
-                ]
+                ],
+                icon: '${APP_INSTALLER_ICON}'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
@@ -358,13 +360,15 @@ describe('Testing build.js:', () => {
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
                 ],
-                type: '${BUILD_TYPE}'
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
             };
             const expectedLinux = {
                 target: [
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
-                ]
+                ],
+                icon: '${APP_INSTALLER_ICON}'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
@@ -408,7 +412,6 @@ describe('Testing build.js:', () => {
             electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
 
             expect(existsSyncSpy).toHaveBeenCalled();
-            // expect(requireSpy).toHaveBeenCalled();
 
             const expected = {
                 linux: [],
@@ -416,6 +419,7 @@ describe('Testing build.js:', () => {
                 win: [],
                 config: {
                     linux: {
+                        icon: '${APP_INSTALLER_ICON}',
                         target: [
                             {
                                 target: 'tar.gz',
@@ -425,6 +429,7 @@ describe('Testing build.js:', () => {
                     },
                     mac: {
                         type: '${BUILD_TYPE}',
+                        icon: '${APP_INSTALLER_ICON}',
                         target: [
                             {
                                 target: 'dmg',
@@ -437,6 +442,7 @@ describe('Testing build.js:', () => {
                         ]
                     },
                     win: {
+                        icon: '${APP_INSTALLER_ICON}',
                         target: [
                             {
                                 target: 'nsis',
@@ -515,13 +521,15 @@ describe('Testing build.js:', () => {
                     { target: 'package', arch: [ 'x64' ] },
                     { target: 'package2', arch: [ 'x64' ] }
                 ],
-                type: '${BUILD_TYPE}'
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
             };
             const expectedLinux = {
                 target: [
                     { target: 'package', arch: [ 'x64' ] },
                     { target: 'package2', arch: [ 'x64' ] }
-                ]
+                ],
+                icon: '${APP_INSTALLER_ICON}'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
@@ -567,13 +575,15 @@ describe('Testing build.js:', () => {
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
                 ],
-                type: '${BUILD_TYPE}'
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
             };
             const expectedLinux = {
                 target: [
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
-                ]
+                ],
+                icon: '${APP_INSTALLER_ICON}'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
@@ -680,7 +690,8 @@ describe('Testing build.js:', () => {
                 target: [
                     { target: 'mas', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
-                ]
+                ],
+                icon: '${APP_INSTALLER_ICON}'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(undefined);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #44. You can find more details there.

### Description
<!-- Describe your changes in detail -->

Apply custom app installer icon when the user is using a custom build configuration. Update `build.js` tests.

### Testing
<!-- Please describe in detail how you tested your changes. -->

```
npm t
```

Also, tested the following use case:

Created a `{project_root}/build.json` file:
```json
{
  "electron": {
    "mac": {
      "package": [
        "tar.gz",
        "dmg",
        "zip"
      ],
      "arch": ["x64"]
    }
  }
}
```

Then ran `cordova build electron --release`. This generated following settings for `mac` platform in the `{project_root}/platforms/electron/build/builder-effective-config.yaml`:
```yaml
mac:
  type: distribution
  icon: installer.png
  target:
    - target: tar.gz
      arch:
        - x64
    - target: dmg
      arch:
        - x64
    - target: zip
      arch:
        - x64
```

**Results:**
Successfully created all 3 packages with a custom app installer icon.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
