### PR TITLE
Append package top-level key options

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -111,6 +111,13 @@ class ElectronBuilder {
                 if (target === 'mas') {
                     userBuildSettings.config['mas'] = {};
                 }
+
+                if (typeof target === 'object' && Object.keys(target).length !== 0) {
+                    const targetKey = Object.keys(target)[0];
+                    userBuildSettings.config[targetKey] = target[targetKey];
+                    target = targetKey;
+                }
+
                 /**
                  * The target of arch values are not validated as electron-builder will handle this.
                  * If the arch value is missing, 64-bit will be defaulted.

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -699,7 +699,7 @@ describe('Testing build.js:', () => {
             expect(electronBuilder.userBuildSettings.config.win).toEqual(expectedWin);
         });
 
-        it('should not append package top-level key options if object is empty.', () => {
+        it('should append package top-level key options if the object is empty.', () => {
             // mock platformConfig, buildConfig and buildOptions Objects
             const platformConfig = {
                 mac: { package: ['pkg', { dmg: { } }], arch: 'arch', signing: 'signing' }
@@ -740,7 +740,7 @@ describe('Testing build.js:', () => {
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
-            expect(electronBuilder.userBuildSettings.config.dmg).toEqual(undefined);
+            expect(electronBuilder.userBuildSettings.config.dmg).toEqual({ });
             expect(electronBuilder.userBuildSettings.config.linux).toEqual(undefined);
             expect(electronBuilder.userBuildSettings.config.windows).toEqual(undefined);
         });

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -748,7 +748,7 @@ describe('Testing build.js:', () => {
         it('should append package top-level key options.', () => {
             // mock platformConfig, buildConfig and buildOptions Objects
             const platformConfig = {
-                mac: { package: ['pkg', { 'dmg': { 'format': 'UDZO' } }], arch: 'arch', signing: 'signing' }
+                mac: { package: ['pkg', { dmg: { format: 'UDZO' } }], arch: 'arch', signing: 'signing' }
             };
             const buildConfig = {
                 electron: platformConfig,
@@ -786,7 +786,7 @@ describe('Testing build.js:', () => {
             };
 
             const expectedDmgOptions = {
-                'format': 'UDZO'
+                format: 'UDZO'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
@@ -798,7 +798,7 @@ describe('Testing build.js:', () => {
         it('should append package top-level key nested options.', () => {
             // mock platformConfig, buildConfig and buildOptions Objects
             const platformConfig = {
-                mac: { package: ['pkg', { 'dmg': { 'format': { 'UDZO': '' } } }], arch: 'arch', signing: 'signing' }
+                mac: { package: ['pkg', { dmg: { format: { UDZO: '' } } }], arch: 'arch', signing: 'signing' }
             };
             const buildConfig = {
                 electron: platformConfig,
@@ -836,7 +836,7 @@ describe('Testing build.js:', () => {
             };
 
             const expectedDmgOptions = {
-                'format': { 'UDZO': '' }
+                format: { UDZO: '' }
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -702,7 +702,7 @@ describe('Testing build.js:', () => {
         it('should not append package top-level key options if object is empty.', () => {
             // mock platformConfig, buildConfig and buildOptions Objects
             const platformConfig = {
-                mac: { package: ['pkg', { }], arch: 'arch', signing: 'signing' }
+                mac: { package: ['pkg', { dmg: { } }], arch: 'arch', signing: 'signing' }
             };
             const buildConfig = {
                 electron: platformConfig,
@@ -733,7 +733,7 @@ describe('Testing build.js:', () => {
             const expectedMac = {
                 target: [
                     { target: 'pkg', arch: 'arch' },
-                    { target: { }, arch: 'arch' }
+                    { target: 'dmg', arch: 'arch' }
                 ],
                 type: '${BUILD_TYPE}',
                 icon: '${APP_INSTALLER_ICON}'

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -699,6 +699,152 @@ describe('Testing build.js:', () => {
             expect(electronBuilder.userBuildSettings.config.win).toEqual(expectedWin);
         });
 
+        it('should not append package top-level key options if object is empty.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                mac: { package: ['pkg', { }], arch: 'arch', signing: 'signing' }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: false, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedMac = {
+                target: [
+                    { target: 'pkg', arch: 'arch' },
+                    { target: { }, arch: 'arch' }
+                ],
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
+            };
+
+            expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
+            expect(electronBuilder.userBuildSettings.config.dmg).toEqual(undefined);
+            expect(electronBuilder.userBuildSettings.config.linux).toEqual(undefined);
+            expect(electronBuilder.userBuildSettings.config.windows).toEqual(undefined);
+        });
+
+        it('should append package top-level key options.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                mac: { package: ['pkg', { 'dmg': { 'format': 'UDZO' } }], arch: 'arch', signing: 'signing' }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: false, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedMac = {
+                target: [
+                    { target: 'pkg', arch: 'arch' },
+                    { target: 'dmg', arch: 'arch' }
+                ],
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
+            };
+
+            const expectedDmgOptions = {
+                'format': 'UDZO'
+            };
+
+            expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
+            expect(electronBuilder.userBuildSettings.config.dmg).toEqual(expectedDmgOptions);
+            expect(electronBuilder.userBuildSettings.config.linux).toEqual(undefined);
+            expect(electronBuilder.userBuildSettings.config.windows).toEqual(undefined);
+        });
+
+        it('should append package top-level key nested options.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                mac: { package: ['pkg', { 'dmg': { 'format': { 'UDZO': '' } } }], arch: 'arch', signing: 'signing' }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: false, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedMac = {
+                target: [
+                    { target: 'pkg', arch: 'arch' },
+                    { target: 'dmg', arch: 'arch' }
+                ],
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}'
+            };
+
+            const expectedDmgOptions = {
+                'format': { 'UDZO': '' }
+            };
+
+            expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
+            expect(electronBuilder.userBuildSettings.config.dmg).toEqual(expectedDmgOptions);
+            expect(electronBuilder.userBuildSettings.config.linux).toEqual(undefined);
+            expect(electronBuilder.userBuildSettings.config.windows).toEqual(undefined);
+        });
+
         it('should fetchPlatformDefaults true.', () => {
             // mock buildOptions Objecet and platformFile path
             const buildOptions = { debug: true, buildConfig: 'build.xml', argv: [] };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #50 

### Description
<!-- Describe your changes in detail -->

Allow to create the top-level mac, linux, windows key contains a set of options instructing electron-builder on how it should build macOS, Linux ar Windows targets. 

### Testing
<!-- Please describe in detail how you tested your changes. -->

```
npm t 
```

Also tested the following scenario.

Created build.json:
```
{
  "electron": {
    "linux": {
      "package": [
        "tar.bz2",
        { "appImage": {
          "systemIntegration": "doNotAsk"
         }
        }
      ],
      "arch": ["x64"]
    },
    "windows": {
      "package": ["portable"],
      "arch": ["x64"]
    }
  }
}
```

Ran: 
```
cordova build electron
```

Which resulted in the following `builder-effective-config.yaml` file:
```
...
linux:
  target:
    - target: tar.bz2
      arch:
        - x64
    - target: appImage
      arch:
        - x64
  icon: installer.png
appImage:
  systemIntegration: doNotAsk
win:
  target:
    - target: portable
      arch:
        - x64
  icon: installer.png
```


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
