### PR TITLE
Added Bundle Node Module Support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -37,6 +37,8 @@ Electron is a framework that uses web technologies (HTML, CSS, and JS) to build 
     - [How to Make the Window Fullscreen](#how-to-make-the-window-fullscreen)
     - [How to Support Node.js and Electron APIs](#how-to-support-nodejs-and-electron-apis)
   - [Customizing the Electron's Main Process](#customizing-the-electrons-main-process)
+  - [Bundling Node Modules](#bundling-node-modules)
+    - [Cordova Package Handling](#cordova-package-handling)
   - [DevTools](#devtools)
   - [Build Configurations](#build-configurations)
     - [Default Build Configurations](#default-build-configurations)
@@ -248,6 +250,33 @@ Set the `nodeIntegration` flag property to `true`.  By default, this property fl
 If it is necessary to customize the Electron's main process beyond the scope of the Electron's configuration settings, chances can be added directly to the `cdv-electron-main.js` file located in `{PROJECT_ROOT_DIR}/platform/electron/platform_www/`. This is the application's main process.
 
 > &#10071; However, it is not recommended to modify this file as the upgrade process for `cordova-electron` is to remove the old platform before adding the new version.
+
+## Bundling Node Modules
+
+Supporting node modules with your application is possible by bundling them with your app. Installing modules, with npm, as a dependency of the Cordova project will automatically bundle them with your app.
+
+Below, is example instructions on how to bundle and enable the use of `lodash`.
+
+1. Create a project using the steps from "[Create a Project](#create-a-project)".
+2. Install `lodash`
+
+   ```bash
+   npm i -S loash
+   ```
+
+3. Enable Node.js support by following the "[How to Support Node.js and Electron APIs](#how-to-support-nodejs-and-electron-apis)"
+4. Import `lodash` in your application using `require`
+
+    ```javascript
+    const _ = require('lodash');
+    ```
+
+### Cordova Package Handling
+
+By default, all Cordova packages are currently installed as `dependencies` of the project.
+
+It is recommended that all Cordova packages are defined as `devDependencies` in the `package.json` file. It is safe to move them manually.
+Packages defined as a dependency will be bundled with the application and can increase the built application's size.
 
 ## DevTools
 

--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -46,7 +46,7 @@ class PackageJsonParser {
 \t- ${cordovaDependencies.join('\n\t- ')}
 
 It is recommended that all Cordova packages are defined as "devDependencies" in the "package.json" file. It is safe to move them manually.
-Note: Defined package as a dependency will be bundled with the application and can increase the built application's size greatly.
+Packages defined as a dependency will be bundled with the application and can increase the built application's size.
 `);
             }
 

--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -19,6 +19,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const { events } = require('cordova-common');
 
 class PackageJsonParser {
     constructor (wwwDir) {
@@ -29,12 +30,27 @@ class PackageJsonParser {
         };
     }
 
-    configure (config) {
+    configure (config, projectPackageJson) {
         if (config) {
             this.package.name = config.packageName() || 'io.cordova.hellocordova';
             this.package.displayName = config.name() || 'HelloCordova';
             this.package.version = config.version() || '1.0.0';
             this.package.description = config.description() || 'A sample Apache Cordova application that responds to the deviceready event.';
+
+            const cordovaDependencies = Object.keys(projectPackageJson.dependencies)
+                .filter((npmPackage) => /^cordova(?!-plugin)-/.test(npmPackage));
+
+            // If Cordova dependencies are detected in "dependencies" of "package.json" warn for potential app package bloating
+            if (cordovaDependencies.length) {
+                events.emit('warn', `The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
+\t- ${cordovaDependencies.join('\n\t- ')}
+
+It is recommended that all Cordova packages are defined as "devDependencies" and is safe to be moved manually.
+Note: Defined package as a dependency will be bundled with the application and can increase the built application's size greatly.
+`);
+            }
+
+            this.package.dependencies = projectPackageJson.dependencies;
 
             this.configureHomepage(config);
             this.configureLicense(config);

--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -45,7 +45,7 @@ class PackageJsonParser {
                 events.emit('warn', `The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
 \t- ${cordovaDependencies.join('\n\t- ')}
 
-It is recommended that all Cordova packages are defined as "devDependencies" and is safe to be moved manually.
+It is recommended that all Cordova packages are defined as "devDependencies" in the "package.json" file. It is safe to move them manually.
 Note: Defined package as a dependency will be bundled with the application and can increase the built application's size greatly.
 `);
             }

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -73,8 +73,10 @@ module.exports.prepare = function (cordovaProject, options) {
             .write();
     }
 
+    const projectPackageJson = JSON.parse(fs.readFileSync(path.join(options.projectRoot, 'package.json'), 'utf8'));
+
     (new PackageJsonParser(this.locations.www))
-        .configure(this.config)
+        .configure(this.config, projectPackageJson)
         .write();
 
     const userElectronSettings = cordovaProject.projectConfig.getPlatformPreference('ElectronSettingsFilePath', 'electron');

--- a/tests/spec/unit/templates/cordova/lib/prepare.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/prepare.spec.js
@@ -234,8 +234,8 @@ describe('Testing prepare.js:', () => {
                         return configPath === defaultConfigPathMock;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -290,8 +290,8 @@ describe('Testing prepare.js:', () => {
                         if (configPath.includes('fail_test_path')) return false;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -335,8 +335,8 @@ describe('Testing prepare.js:', () => {
                         if (configPath.includes('pass_test_path')) return true;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -381,8 +381,8 @@ describe('Testing prepare.js:', () => {
                         return configPath === ownConfigPathMock;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -438,8 +438,8 @@ describe('Testing prepare.js:', () => {
                         return configPath !== ownConfigPathMock && configPath !== defaultConfigPathMock;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -494,8 +494,8 @@ describe('Testing prepare.js:', () => {
                         return srcManifestPath === srcManifestPathMock;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -549,8 +549,8 @@ describe('Testing prepare.js:', () => {
                         return srcManifestPath !== srcManifestPathMock;
                     },
                     copySync: copySyncSpy,
-                    readFileSync: function (path) {
-                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                    readFileSync: function (filePath) {
+                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }

--- a/tests/spec/unit/templates/cordova/lib/prepare.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/prepare.spec.js
@@ -41,6 +41,21 @@ function mockGetImageItem (data) {
     }, data);
 }
 
+const defaultMockProjectPackageJson = `{
+    "name": "io.cordova.electronTest",
+    "displayName": "electronTest",
+    "version": "1.0.0",
+    "description": "A Sample Apache Cordova Electron Application.",
+    "author": "Apache Cordova Team",
+    "license": "Apache-2.0",
+    "dependencies": { "cordova-electron": "^1.0.2" },
+    "devDependencies": {},
+    "cordova": { 
+        "plugins": {},
+        "platforms": ["electron"]
+    }
+}`;
+
 const cordovaProjectDefault = {
     root: 'mock',
     projectConfig: {
@@ -83,7 +98,9 @@ const cordovaProjectDefault = {
 const locationsDefault = cordovaProjectDefault.locations;
 
 let fakeParserConstructorSpy;
-let fakeParserConfigureSpy;
+let fakeManifestJsonParserConfigureSpy;
+let fakePackageJsonParserConfigureSpy;
+let fakeSettingJsonParserConfigureSpy;
 let fakeParserWriteSpy;
 let fakeConfigParserConstructorSpy;
 let fakeConfigParserWriteSpy;
@@ -97,7 +114,11 @@ let updateSplashScreensFake;
 
 function createSpies () {
     fakeParserConstructorSpy = jasmine.createSpy('fakeParserConstructorSpy');
-    fakeParserConfigureSpy = jasmine.createSpy('fakeParserConfigureSpy');
+
+    fakeManifestJsonParserConfigureSpy = jasmine.createSpy('fakeManifestJsonParserConfigureSpy');
+    fakePackageJsonParserConfigureSpy = jasmine.createSpy('fakePackageJsonParserConfigureSpy');
+    fakeSettingJsonParserConfigureSpy = jasmine.createSpy('fakeSettingJsonParserConfigureSpy');
+
     fakeParserWriteSpy = jasmine.createSpy('fakeParserWriteSpy');
 
     fakeConfigParserConstructorSpy = jasmine.createSpy('fakeConfigParserConstructorSpy');
@@ -136,12 +157,29 @@ class FakeParser {
     constructor () {
         fakeParserConstructorSpy();
     }
-    configure (options, userElectronFile) {
-        fakeParserConfigureSpy(options, userElectronFile);
-        return this;
-    }
     write () {
         fakeParserWriteSpy();
+        return this;
+    }
+}
+
+class FakeManifestJsonParser extends FakeParser {
+    configure (configXmlParser) {
+        fakeManifestJsonParserConfigureSpy(configXmlParser);
+        return this;
+    }
+}
+
+class FakePackageJsonParser extends FakeParser {
+    configure (configXmlParser, projectPackageJson) {
+        fakePackageJsonParserConfigureSpy(configXmlParser, projectPackageJson);
+        return this;
+    }
+}
+
+class FakeSettingJsonParser extends FakeParser {
+    configure (options, userElectronFile) {
+        fakeSettingJsonParserConfigureSpy(options, userElectronFile);
         return this;
     }
 }
@@ -195,7 +233,12 @@ describe('Testing prepare.js:', () => {
                     existsSync: function (configPath) {
                         return configPath === defaultConfigPathMock;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -203,13 +246,13 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(defaultConfigPathMock, ownConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -217,7 +260,9 @@ describe('Testing prepare.js:', () => {
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
                 expect(fakeParserConstructorSpy).toHaveBeenCalled();
                 expect(fakeConfigParserConstructorSpy).toHaveBeenCalled();
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakeParserWriteSpy).toHaveBeenCalled();
                 expect(fakeConfigParserWriteSpy).toHaveBeenCalled();
 
@@ -244,7 +289,12 @@ describe('Testing prepare.js:', () => {
                         if (configPath === defaultConfigPathMock) return true;
                         if (configPath.includes('fail_test_path')) return false;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -252,16 +302,18 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = (name, platform) => 'fail_test_path';
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
-                const actual = fakeParserConfigureSpy.calls.argsFor(2)[1];
+                expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
+                const actual = fakeSettingJsonParserConfigureSpy.calls.argsFor(0)[1];
                 expect(actual).toEqual(undefined);
             });
         });
@@ -282,7 +334,12 @@ describe('Testing prepare.js:', () => {
                         if (configPath === defaultConfigPathMock) return true;
                         if (configPath.includes('pass_test_path')) return true;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -290,16 +347,18 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = (name, platform) => 'pass_test_path';
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
-                const actual = fakeParserConfigureSpy.calls.argsFor(2)[1];
+                expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
+                const actual = fakeSettingJsonParserConfigureSpy.calls.argsFor(0)[1];
                 expect(actual).toContain('pass_test_path');
             });
         });
@@ -321,7 +380,12 @@ describe('Testing prepare.js:', () => {
                     existsSync: function (configPath) {
                         return configPath === ownConfigPathMock;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -329,13 +393,13 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(ownConfigPathMock, defaultConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -343,7 +407,9 @@ describe('Testing prepare.js:', () => {
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
                 expect(fakeParserConstructorSpy).toHaveBeenCalled();
                 expect(fakeConfigParserConstructorSpy).toHaveBeenCalled();
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakeParserWriteSpy).toHaveBeenCalled();
                 expect(fakeConfigParserWriteSpy).toHaveBeenCalled();
 
@@ -371,7 +437,12 @@ describe('Testing prepare.js:', () => {
                     existsSync: function (configPath) {
                         return configPath !== ownConfigPathMock && configPath !== defaultConfigPathMock;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -379,13 +450,13 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(sourceCfgMock.path, ownConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -393,7 +464,9 @@ describe('Testing prepare.js:', () => {
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
                 expect(fakeParserConstructorSpy).toHaveBeenCalled();
                 expect(fakeConfigParserConstructorSpy).toHaveBeenCalled();
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeManifestJsonParserConfigureSpy).not.toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakeParserWriteSpy).toHaveBeenCalled();
                 expect(fakeConfigParserWriteSpy).toHaveBeenCalled();
 
@@ -420,7 +493,12 @@ describe('Testing prepare.js:', () => {
                     existsSync: function (srcManifestPath) {
                         return srcManifestPath === srcManifestPathMock;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -428,13 +506,13 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(srcManifestPathMock, manifestPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -442,7 +520,9 @@ describe('Testing prepare.js:', () => {
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
                 expect(fakeParserConstructorSpy).toHaveBeenCalled();
                 expect(fakeConfigParserConstructorSpy).toHaveBeenCalled();
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeManifestJsonParserConfigureSpy).not.toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakeParserWriteSpy).toHaveBeenCalled();
                 expect(fakeConfigParserWriteSpy).toHaveBeenCalled();
 
@@ -468,7 +548,12 @@ describe('Testing prepare.js:', () => {
                     existsSync: function (srcManifestPath) {
                         return srcManifestPath !== srcManifestPathMock;
                     },
-                    copySync: copySyncSpy
+                    copySync: copySyncSpy,
+                    readFileSync: function (path) {
+                        if (path === 'TMP_PROJECT_ROOT/package.json') {
+                            return defaultMockProjectPackageJson;
+                        }
+                    }
                 });
 
                 // override classes and methods called in modules.export.prepare
@@ -476,20 +561,22 @@ describe('Testing prepare.js:', () => {
                 prepare.__set__('xmlHelpers', xmlHelpersMock);
                 prepare.__set__('updateIcons', updateIconsFake);
                 prepare.__set__('updateSplashScreens', updateSplashScreensFake);
-                prepare.__set__('ManifestJsonParser', FakeParser);
-                prepare.__set__('PackageJsonParser', FakeParser);
-                prepare.__set__('SettingJsonParser', FakeParser);
+                prepare.__set__('ManifestJsonParser', FakeManifestJsonParser);
+                prepare.__set__('PackageJsonParser', FakePackageJsonParser);
+                prepare.__set__('SettingJsonParser', FakeSettingJsonParser);
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, {}, api);
+                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
 
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
                 expect(fakeParserConstructorSpy).toHaveBeenCalled();
                 expect(fakeConfigParserConstructorSpy).toHaveBeenCalled();
-                expect(fakeParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
+                expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakeParserWriteSpy).toHaveBeenCalled();
                 expect(fakeConfigParserWriteSpy).toHaveBeenCalled();
 


### PR DESCRIPTION
### Platforms affected
electron

### Motivation and Context
Support Bundling Node Modules

fixes: #52

### Description
This PR is a possible solution to support the bundling of node_modules inside the Electron built package.

The concept is that when working on an app, we add specific npm packages (`npm i -S <package>`) to the root directory of the Cordova project as a `dependencies`, not `devDependencies`.

For example, if we wanted to use `lodash`:

1. Config the Cordova Project to support `nodeIntegration`.

  Follow these guides:
  - [Customizing the Application's Window Options](https://github.com/erisu/cordova-electron/blob/bundle-node-modules/DOCUMENTATION.md#customizing-the-applications-window-options)
  - [How to support Node.js and Electron APIs?](https://github.com/erisu/cordova-electron/blob/bundle-node-modules/DOCUMENTATION.md#how-to-support-nodejs-and-electron-apis)

2. Install the `lodash` npm node modules.

  ```
  npm i -S lodash
  ```

**Now what happens?:**
- During testing with the `cordova run electron --nobuild` command, it will spawn an Electron process and use the `lodash` modules from `<project_root>/node_modules/lodash`.

  This is how it operated before this PR.

- When building, the Cordova build process will copy the Cordova's project `dependencies` from `package.json` to the built application's `package.json`. During the build process, it will `npm install` all the modules within the app directory that is packaged.

  This was added from this PR.

**Note:** With the current Cordova CLI, all platforms are added as `dependencies`. IT SHOULD BE ok to manually move these dependencies to `devDependencies`. These dependencies contain only the build tools and templates and are not needed in your bundled app. All it will do is increase the application's size.

### Testing
- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
