### PR TITLE
Remove maintainer option from the Linux build json file

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -238,7 +238,6 @@ class ElectronBuilder {
         // const isDevelopment = false;
         const packageJson = require(path.join(this.api.locations.www, 'package.json'));
         const userConfig = {
-            APP_AUTHOR: packageJson.author,
             APP_ID: packageJson.name,
             APP_TITLE: packageJson.displayName,
             APP_INSTALLER_ICON: 'installer.png',

--- a/bin/templates/cordova/lib/build/linux.json
+++ b/bin/templates/cordova/lib/build/linux.json
@@ -2,7 +2,6 @@
   "linux": [],
   "config": {
     "linux": {
-      "maintainer": "${APP_AUTHOR}",
       "icon": "${APP_INSTALLER_ICON}",
       "target": [
         {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Remove the `maintainer` option `build/linux.json`, as `maintainer` and `vendor` defaults to the `author` value set in the `{project_root}/platforms/electron/www/package.json`. I believe it's unnecessary to get the option from the `package.json` file and then manually append it to the `build/linux.json` file.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Built all available packages for Linux. As well, ran `npm t`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
