### PR TITLE
Allow users to set Linux app category

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -106,6 +106,9 @@ class ElectronBuilder {
         // eslint-disable-next-line no-template-curly-in-string
         if (platform === 'mac') userBuildSettings.config[platform].type = '${BUILD_TYPE}';
 
+        // Only Linux has an application category (String). Default value - Utility.
+        if (platform === 'linux' && platformConfigs.category) userBuildSettings.config[platform].category = platformConfigs.category;
+
         if (platformConfigs.package) {
             platformConfigs.package.forEach((target) => {
                 if (target === 'mas') {

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -191,7 +191,7 @@ describe('Testing build.js:', () => {
             const platformConfig = {
                 mac: { package: ['package', 'package2'], arch: 'arch', signing: { debug: 'debug', release: 'release', store: 'store' } },
                 win: { package: ['package', 'package2'], arch: 'arch', signing: { debug: 'debug', release: 'release' } },
-                linux: { package: ['package', 'package2'], arch: 'arch' },
+                linux: { package: ['package', 'package2'], arch: 'arch', category: 'Game' },
                 darwin: {}
             };
             const buildConfig = {
@@ -233,7 +233,8 @@ describe('Testing build.js:', () => {
                     { target: 'package', arch: 'arch' },
                     { target: 'package2', arch: 'arch' }
                 ],
-                icon: '${APP_INSTALLER_ICON}'
+                icon: '${APP_INSTALLER_ICON}',
+                category: 'Game'
             };
 
             expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #56 

### Description
<!-- Describe your changes in detail -->

If the platform is Linux and has a category field set in the custom `build.json` file, append category to the `build/linux.json` file.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested two cases, when the Linux app category is set and not. 

**When the category is set:**
```json
{
  "electron": {
    "linux": {
      "package": [
        "tar.gz"
      ],
      "arch": ["x64"],
      "category": "Game"
    }
}
```
_**Result:** created and `tar.gz` package with the correct category name - "Game"._


**When the category is not set:**
```json
{
  "electron": {
    "linux": {
      "package": [
        "tar.gz"
      ],
      "arch": ["x64"]
    }
}
```
_**Result:** created and `tar.gz` package with a default category name - "Utility"._

Also, ran `npm t`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
