### PR TITLE
Fix Bundle Feature's Project Path Issue & Warning Output

### DIFF
--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -42,7 +42,9 @@ class PackageJsonParser {
 
             // If Cordova dependencies are detected in "dependencies" of "package.json" warn for potential app package bloating
             if (cordovaDependencies.length) {
-                events.emit('warn', `The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
+                events.emit('warn', 'The built Electron package size may be larger than necessary. Please run in verbose for more details.');
+
+                events.emit('verbose', `The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
 \t- ${cordovaDependencies.join('\n\t- ')}
 
 It is recommended that all Cordova packages are defined as "devDependencies" in the "package.json" file. It is safe to move them manually.

--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -42,9 +42,9 @@ class PackageJsonParser {
 
             // If Cordova dependencies are detected in "dependencies" of "package.json" warn for potential app package bloating
             if (cordovaDependencies.length) {
-                events.emit('warn', 'The built Electron package size may be larger than necessary. Please run in verbose for more details.');
+                events.emit('warn', '[Cordova Electron] The built package size may be larger than necessary. Please run with --verbose for more details.');
 
-                events.emit('verbose', `The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
+                events.emit('verbose', `[Cordova Electron] The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
 \t- ${cordovaDependencies.join('\n\t- ')}
 
 It is recommended that all Cordova packages are defined as "devDependencies" in the "package.json" file. It is safe to move them manually.

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -73,7 +73,7 @@ module.exports.prepare = function (cordovaProject, options) {
             .write();
     }
 
-    const projectPackageJson = JSON.parse(fs.readFileSync(path.join(options.projectRoot, 'package.json'), 'utf8'));
+    const projectPackageJson = JSON.parse(fs.readFileSync(path.join(cordovaProject.root, 'package.json'), 'utf8'));
 
     (new PackageJsonParser(this.locations.www))
         .configure(this.config, projectPackageJson)

--- a/tests/spec/unit/templates/cordova/lib/PackageJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/PackageJsonParser.spec.js
@@ -132,10 +132,14 @@ describe('PackageJsonParser class', () => {
     it('should warn that cordova-electron is defined as dependency.', () => {
         packageJsonParser = new PackageJsonParser(locations.www).configure(cfg, defaultMockProjectPackageJson);
 
-        const actual = emitSpy.calls.argsFor(0)[1];
-        const expectedPartial = 'The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.';
-
         expect(emitSpy).toHaveBeenCalled();
+
+        let actual = emitSpy.calls.argsFor(0)[1];
+        let expectedPartial = '[Cordova Electron] The built package size may be larger than necessary.';
+        expect(actual).toContain(expectedPartial);
+
+        actual = emitSpy.calls.argsFor(1)[1];
+        expectedPartial = '[Cordova Electron] The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.';
         expect(actual).toContain(expectedPartial);
         expect(actual).toContain('cordova-electron');
     });

--- a/tests/spec/unit/templates/cordova/lib/prepare.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/prepare.spec.js
@@ -57,9 +57,9 @@ const defaultMockProjectPackageJson = `{
 }`;
 
 const cordovaProjectDefault = {
-    root: 'mock',
+    root: 'MOCK_PROJECT_ROOT',
     projectConfig: {
-        path: path.join('mock', 'config.xml'),
+        path: path.join('MOCK_PROJECT_ROOT', 'config.xml'),
         cdvNamespacePrefix: 'cdv',
         doc: {
             getroot: function () {
@@ -88,10 +88,10 @@ const cordovaProjectDefault = {
         }
     },
     locations: {
-        buildRes: path.join('mock', 'build-res'),
-        www: path.join('mock', 'www'),
-        configXml: path.join('mock', 'config.xml'),
-        platformRootDir: path.join('mock', 'platform_www')
+        buildRes: path.join('MOCK_PROJECT_ROOT', 'build-res'),
+        www: path.join('MOCK_PROJECT_ROOT', 'www'),
+        configXml: path.join('MOCK_PROJECT_ROOT', 'config.xml'),
+        platformRootDir: path.join('MOCK_PROJECT_ROOT', 'platform_www')
     }
 };
 
@@ -235,7 +235,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -252,7 +252,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(defaultConfigPathMock, ownConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -291,7 +291,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -308,7 +308,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = (name, platform) => 'fail_test_path';
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
@@ -336,7 +336,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -353,7 +353,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = (name, platform) => 'pass_test_path';
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
@@ -382,7 +382,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -399,7 +399,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(ownConfigPathMock, defaultConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -439,7 +439,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -456,7 +456,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(sourceCfgMock.path, ownConfigPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -495,7 +495,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -512,7 +512,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(copySyncSpy).toHaveBeenCalledWith(srcManifestPathMock, manifestPathMock);
                 expect(mergeXmlSpy).toHaveBeenCalled();
@@ -550,7 +550,7 @@ describe('Testing prepare.js:', () => {
                     },
                     copySync: copySyncSpy,
                     readFileSync: function (filePath) {
-                        if (filePath === path.join('TMP_PROJECT_ROOT', 'package.json')) {
+                        if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
                         }
                     }
@@ -567,7 +567,7 @@ describe('Testing prepare.js:', () => {
 
                 cordovaProject.projectConfig.getPlatformPreference = () => undefined;
 
-                prepare.prepare.call(api, cordovaProject, { projectRoot: 'TMP_PROJECT_ROOT' }, api);
+                prepare.prepare.call(api, cordovaProject, { }, api);
 
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();
@@ -713,7 +713,7 @@ describe('Testing prepare.js:', () => {
         it('should update splash screen location in config.xml', () => {
             const resourceMap = [
                 {
-                    [path.join('res', 'electron', 'splash.png')]: path.join('mock', 'www', '.cdv', 'splashScreen.png')
+                    [path.join('res', 'electron', 'splash.png')]: path.join('MOCK_PROJECT_ROOT', 'www', '.cdv', 'splashScreen.png')
                 }
             ];
 
@@ -723,7 +723,7 @@ describe('Testing prepare.js:', () => {
             const splashScreenPath = resourceMap[0][elementKeys];
             const splashScreenRelativePath = path.relative(locations.www, splashScreenPath);
 
-            expect(path.join('mock', 'www', '.cdv', 'splashScreen.png')).toEqual(splashScreenPath);
+            expect(path.join('MOCK_PROJECT_ROOT', 'www', '.cdv', 'splashScreen.png')).toEqual(splashScreenPath);
             expect(path.join('.cdv', 'splashScreen.png')).toEqual(splashScreenRelativePath);
         });
     });
@@ -1405,8 +1405,8 @@ describe('Testing prepare.js:', () => {
             expect(shellLsSpy).toHaveBeenCalled();
 
             const expected = [
-                { [path.join('res', 'logo.png')]: path.join('mock', 'www', 'img', 'app.png') },
-                { [path.join('res', 'logo.png')]: path.join('mock', 'build-res', 'installer.png') }
+                { [path.join('res', 'logo.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'app.png') },
+                { [path.join('res', 'logo.png')]: path.join('MOCK_PROJECT_ROOT', 'build-res', 'installer.png') }
             ];
 
             expect(expected).toEqual(actual);
@@ -1430,7 +1430,7 @@ describe('Testing prepare.js:', () => {
             expect(shellLsSpy).toHaveBeenCalled();
 
             const expected = [
-                { [path.join('res', 'electron', 'cordova_512.png')]: path.join('mock', 'build-res', 'installer.png') }
+                { [path.join('res', 'electron', 'cordova_512.png')]: path.join('MOCK_PROJECT_ROOT', 'build-res', 'installer.png') }
             ];
 
             expect(expected).toEqual(actual);
@@ -1461,8 +1461,8 @@ describe('Testing prepare.js:', () => {
             expect(shellLsSpy).toHaveBeenCalled();
 
             const expected = [
-                { [path.join('res', 'electron', 'cordova.png')]: path.join('mock', 'www', 'img', 'app.png') },
-                { [path.join('res', 'electron', 'cordova_512.png')]: path.join('mock', 'build-res', 'installer.png') }
+                { [path.join('res', 'electron', 'cordova.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'app.png') },
+                { [path.join('res', 'electron', 'cordova_512.png')]: path.join('MOCK_PROJECT_ROOT', 'build-res', 'installer.png') }
             ];
 
             expect(expected).toEqual(actual);
@@ -1493,11 +1493,11 @@ describe('Testing prepare.js:', () => {
             expect(shellLsSpy).toHaveBeenCalled();
 
             const expected = [
-                { [path.join('res', 'electron', 'cordova@1.5x.png')]: path.join('mock', 'www', 'img', 'icon@1.5x.png') },
-                { [path.join('res', 'electron', 'cordova@2x.png')]: path.join('mock', 'www', 'img', 'icon@2x.png') },
-                { [path.join('res', 'electron', 'cordova@4x.png')]: path.join('mock', 'www', 'img', 'icon@4x.png') },
-                { [path.join('res', 'electron', 'cordova@8x.png')]: path.join('mock', 'www', 'img', 'icon@8x.png') },
-                { [path.join('res', 'electron', 'cordova.png')]: path.join('mock', 'www', 'img', 'icon.png') }
+                { [path.join('res', 'electron', 'cordova@1.5x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@1.5x.png') },
+                { [path.join('res', 'electron', 'cordova@2x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@2x.png') },
+                { [path.join('res', 'electron', 'cordova@4x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@4x.png') },
+                { [path.join('res', 'electron', 'cordova@8x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@8x.png') },
+                { [path.join('res', 'electron', 'cordova.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon.png') }
             ];
 
             expect(expected).toEqual(actual);
@@ -1534,12 +1534,12 @@ describe('Testing prepare.js:', () => {
             expect(shellLsSpy).toHaveBeenCalled();
 
             const expected = [
-                { [path.join('res', 'electron', 'cordova_512.png')]: path.join('mock', 'build-res', 'installer.png') },
-                { [path.join('res', 'electron', 'cordova@1.5x.png')]: path.join('mock', 'www', 'img', 'icon@1.5x.png') },
-                { [path.join('res', 'electron', 'cordova@2x.png')]: path.join('mock', 'www', 'img', 'icon@2x.png') },
-                { [path.join('res', 'electron', 'cordova@4x.png')]: path.join('mock', 'www', 'img', 'icon@4x.png') },
-                { [path.join('res', 'electron', 'cordova@8x.png')]: path.join('mock', 'www', 'img', 'icon@8x.png') },
-                { [path.join('res', 'electron', 'cordova.png')]: path.join('mock', 'www', 'img', 'icon.png') }
+                { [path.join('res', 'electron', 'cordova_512.png')]: path.join('MOCK_PROJECT_ROOT', 'build-res', 'installer.png') },
+                { [path.join('res', 'electron', 'cordova@1.5x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@1.5x.png') },
+                { [path.join('res', 'electron', 'cordova@2x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@2x.png') },
+                { [path.join('res', 'electron', 'cordova@4x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@4x.png') },
+                { [path.join('res', 'electron', 'cordova@8x.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon@8x.png') },
+                { [path.join('res', 'electron', 'cordova.png')]: path.join('MOCK_PROJECT_ROOT', 'www', 'img', 'icon.png') }
             ];
 
             expect(expected).toEqual(actual);
@@ -1560,7 +1560,7 @@ describe('Testing prepare.js:', () => {
             expect(shellLsSpy).toHaveBeenCalled();
 
             const expected = [
-                { [path.join('res', 'electron', 'splash.png')]: path.join('mock', 'www', '.cdv', 'splashScreen.png') }
+                { [path.join('res', 'electron', 'splash.png')]: path.join('MOCK_PROJECT_ROOT', 'www', '.cdv', 'splashScreen.png') }
             ];
 
             expect(expected).toEqual(actual);


### PR DESCRIPTION
### Motivation and Context
The project root path was undefined and prevent electron platform from adding.

### Description
This uses the correct object that always contains the project root path.

### Testing
- `npm t`
- `cordova platform add ...`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
