### PR TITLE
Fixed package.json Version to 1.1.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-electron",
-  "version": "1.0.2",
+  "version": "1.1.0-dev",
   "description": "electron apps as a target for cordova developers",
   "main": "bin/templates/cordova/Api.js",
   "bin": "bin/create",


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
There was a discrepancy between the `package.json` and `package-lock.json`.
This PR sets `package.json` to match with `package-lock.json` and prepare for the minor release.

### Description
Updated `package.json`

### Testing
none

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
