### PR TITLE
Append overridable/top-level per platform options

### DIFF
--- a/bin/templates/cordova/lib/build.js
+++ b/bin/templates/cordova/lib/build.js
@@ -79,6 +79,12 @@ class ElectronBuilder {
                     platformConfigs,
                     userBuildSettings
                 );
+
+                this.___overridablePerPlatformOptions(
+                    (platform === 'windows' ? 'win' : platform),
+                    platformConfigs,
+                    userBuildSettings
+                );
             }
 
             this.userBuildSettings = userBuildSettings;
@@ -105,9 +111,6 @@ class ElectronBuilder {
         // Only macOS has a build type distinction. (development or distribution)
         // eslint-disable-next-line no-template-curly-in-string
         if (platform === 'mac') userBuildSettings.config[platform].type = '${BUILD_TYPE}';
-
-        // Only Linux has an application category (String). Default value - Utility.
-        if (platform === 'linux' && platformConfigs.category) userBuildSettings.config[platform].category = platformConfigs.category;
 
         if (platformConfigs.package) {
             platformConfigs.package.forEach((target) => {
@@ -149,6 +152,68 @@ class ElectronBuilder {
 
         if (platformConfigs.signing) {
             this.__appendUserSigning(platform, platformConfigs.signing, userBuildSettings);
+        }
+    }
+
+    ___overridablePerPlatformOptions (platform, platformConfigs, userBuildSettings) {
+        const PLATFORM_TOP_LEVEL_OPTIONS = {
+            allPlatforms: [
+                'appId',
+                'artifactName',
+                'asar',
+                'compression',
+                'detectUpdateChannel',
+                'electronUpdaterCompatibility',
+                'extraFiles',
+                'extraResources',
+                'fileAssociations',
+                'files',
+                'forceCodeSigning',
+                'generateUpdatesFilesForAllChannels',
+                'icon',
+                'publish'
+            ],
+            linux: [
+                'category',
+                'description',
+                'desktop',
+                'executableName',
+                'maintainer',
+                'mimeTypes',
+                'synopsis',
+                'vendor'
+            ],
+            mac: [
+                'binaries',
+                'bundleShortVersion',
+                'bundleVersion',
+                'category',
+                'darkModeSupport',
+                'electronLanguages',
+                'extendInfo',
+                'extraDistFiles',
+                'helperBundleId',
+                'minimumSystemVersion'
+            ],
+            win: [
+                'legalTrademarks',
+                'publisherName',
+                'requestedExecutionLevel',
+                'rfc3161TimeStampServer',
+                'signAndEditExecutable',
+                'signDlls',
+                'timeStampServer',
+                'verifyUpdateCodeSignature'
+            ]
+        };
+
+        for (let option in platformConfigs) {
+            if (
+                PLATFORM_TOP_LEVEL_OPTIONS['allPlatforms'].includes(option)
+                || PLATFORM_TOP_LEVEL_OPTIONS[platform].includes(option)
+            ) {
+                userBuildSettings.config[platform][option] = platformConfigs[option];
+            }
         }
     }
 

--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -846,6 +846,323 @@ describe('Testing build.js:', () => {
             expect(electronBuilder.userBuildSettings.config.windows).toEqual(undefined);
         });
 
+        it('should set overridable per platform options.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                mac: {
+                    package: ['package', 'package2'],
+                    arch: 'arch',
+                    appId: 'com.test.app',
+                    artifactName: '${productName}-${version}.${ext}',
+                    compression: 'normal',
+                    files: [
+                        'test/files/file1',
+                        'test/files/file2'
+                    ],
+                    extraResources: [
+                        'test/resources/file1',
+                        'test/resources/file2'
+                    ],
+                    extraFiles: [
+                        'test/extra/files/file1',
+                        'test/extra/files/file2'
+                    ],
+                    asar: false,
+                    fileAssociations: [
+                        {
+                            ext: 'png',
+                            name: 'PNG'
+                        }
+                    ],
+                    forceCodeSigning: false,
+                    electronUpdaterCompatibility: '>=2.15',
+                    publish: ['github', 'bintray'],
+                    detectUpdateChannel: false,
+                    generateUpdatesFilesForAllChannels: false
+                }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: true, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedMac = {
+                target: [
+                    { target: 'package', arch: 'arch' },
+                    { target: 'package2', arch: 'arch' }
+                ],
+                type: '${BUILD_TYPE}',
+                icon: '${APP_INSTALLER_ICON}',
+                appId: 'com.test.app',
+                artifactName: '${productName}-${version}.${ext}',
+                compression: 'normal',
+                files: [
+                    'test/files/file1',
+                    'test/files/file2'
+                ],
+                extraResources: [
+                    'test/resources/file1',
+                    'test/resources/file2'
+                ],
+                extraFiles: [
+                    'test/extra/files/file1',
+                    'test/extra/files/file2'
+                ],
+                asar: false,
+                fileAssociations: [
+                    {
+                        ext: 'png',
+                        name: 'PNG'
+                    }
+                ],
+                forceCodeSigning: false,
+                electronUpdaterCompatibility: '>=2.15',
+                publish: ['github', 'bintray'],
+                detectUpdateChannel: false,
+                generateUpdatesFilesForAllChannels: false
+            };
+
+            expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
+        });
+
+        it('should set top-level macOS specific.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                mac: {
+                    package: ['package', 'package2'],
+                    arch: 'arch',
+                    category: 'public.app-category.developer-tools',
+                    icon: 'build/icon.icns',
+                    bundleVersion: 'CFBundleVersion',
+                    bundleShortVersion: 'CFBundleShortVersionString',
+                    darkModeSupport: true,
+                    helperBundleId: '${appBundleIdentifier}.helper',
+                    extendInfo: 'Info.plist',
+                    binaries: [
+                        'test/binaries/file1',
+                        'test/binaries/file2'
+                    ],
+                    minimumSystemVersion: '10.0.10',
+                    electronLanguages: [
+                        'en',
+                        'jp',
+                        'ru'
+                    ],
+                    extraDistFiles: [
+                        'test/extraDist/file1',
+                        'test/extraDist/file2'
+                    ]
+                }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: true, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedMac = {
+                target: [
+                    { target: 'package', arch: 'arch' },
+                    { target: 'package2', arch: 'arch' }
+                ],
+                type: '${BUILD_TYPE}',
+                category: 'public.app-category.developer-tools',
+                icon: 'build/icon.icns',
+                bundleVersion: 'CFBundleVersion',
+                bundleShortVersion: 'CFBundleShortVersionString',
+                darkModeSupport: true,
+                helperBundleId: '${appBundleIdentifier}.helper',
+                extendInfo: 'Info.plist',
+                binaries: [
+                    'test/binaries/file1',
+                    'test/binaries/file2'
+                ],
+                minimumSystemVersion: '10.0.10',
+                electronLanguages: [
+                    'en',
+                    'jp',
+                    'ru'
+                ],
+                extraDistFiles: [
+                    'test/extraDist/file1',
+                    'test/extraDist/file2'
+                ]
+            };
+
+            expect(electronBuilder.userBuildSettings.config.mac).toEqual(expectedMac);
+        });
+
+        it('should set top-level Windows specific.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                windows: {
+                    package: ['package', 'package2'],
+                    arch: 'arch',
+                    icon: 'build/icon.icns',
+                    legalTrademarks: 'trademarks and registered trademarks',
+                    rfc3161TimeStampServer: 'http://timestamp.comodoca.com/rfc3161',
+                    timeStampServer: 'http://timestamp.verisign.com/scripts/timstamp.dll',
+                    publisherName: 'publisher name',
+                    verifyUpdateCodeSignature: true,
+                    requestedExecutionLevel: 'asInvoker',
+                    signAndEditExecutable: true,
+                    signDlls: false
+                }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: true, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedWindows = {
+                target: [
+                    { target: 'package', arch: 'arch' },
+                    { target: 'package2', arch: 'arch' }
+                ],
+                icon: 'build/icon.icns',
+                legalTrademarks: 'trademarks and registered trademarks',
+                rfc3161TimeStampServer: 'http://timestamp.comodoca.com/rfc3161',
+                timeStampServer: 'http://timestamp.verisign.com/scripts/timstamp.dll',
+                publisherName: 'publisher name',
+                verifyUpdateCodeSignature: true,
+                requestedExecutionLevel: 'asInvoker',
+                signAndEditExecutable: true,
+                signDlls: false
+            };
+
+            expect(electronBuilder.userBuildSettings.config.win).toEqual(expectedWindows);
+        });
+
+        it('should set top-level Linux specific.', () => {
+            // mock platformConfig, buildConfig and buildOptions Objects
+            const platformConfig = {
+                linux: {
+                    package: ['package', 'package2'],
+                    arch: 'arch',
+                    maintainer: 'maintainer',
+                    vendor: 'vendor',
+                    executableName: 'productName',
+                    icon: 'path to icon set directory or one png file',
+                    synopsis: 'short description',
+                    description: 'description',
+                    category: 'Utility',
+                    mimeTypes: [
+                        'type1',
+                        'type2'
+                    ],
+                    desktop: 'desktop file entries'
+                }
+            };
+            const buildConfig = {
+                electron: platformConfig,
+                author: 'Apache',
+                name: 'Guy',
+                displayName: 'HelloWorld',
+                APP_BUILD_DIR: api.locations.build,
+                APP_BUILD_RES_DIR: api.locations.buildRes,
+                APP_WWW_DIR: api.locations.www
+            };
+
+            const buildOptions = { debug: true, buildConfig: buildConfig, argv: [] };
+
+            // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
+            requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+            build.__set__({ require: requireSpy });
+
+            const __validateUserPlatformBuildSettingsSpy = jasmine.createSpy('__validateUserPlatformBuildSettings').and.returnValue(true);
+            build.__set__({ __validateUserPlatformBuildSettings: __validateUserPlatformBuildSettingsSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api).configureUserBuildSettings();
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(requireSpy).toHaveBeenCalled();
+
+            const expectedLinux = {
+                target: [
+                    { target: 'package', arch: 'arch' },
+                    { target: 'package2', arch: 'arch' }
+                ],
+                maintainer: 'maintainer',
+                vendor: 'vendor',
+                executableName: 'productName',
+                icon: 'path to icon set directory or one png file',
+                synopsis: 'short description',
+                description: 'description',
+                category: 'Utility',
+                mimeTypes: [
+                    'type1',
+                    'type2'
+                ],
+                desktop: 'desktop file entries'
+            };
+
+            expect(electronBuilder.userBuildSettings.config.linux).toEqual(expectedLinux);
+        });
+
         it('should fetchPlatformDefaults true.', () => {
             // mock buildOptions Objecet and platformFile path
             const buildOptions = { debug: true, buildConfig: 'build.xml', argv: [] };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Allow leveraging more Electron Builder options.
Resolves  #72, #74

### Description
<!-- Describe your changes in detail -->

Append [Overridable per Platform Options](https://www.electron.build/configuration/configuration#overridable-per-platform-options) build configuration. 

As well, the top-level [macOS](https://www.electron.build/configuration/mac), [Windows](https://www.electron.build/configuration/win), [Linux](https://www.electron.build/configuration/linux) key options. 

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- ~~[ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary

