### PR TITLE
Updated Version to Return from `package.json`

### DIFF
--- a/bin/templates/cordova/version
+++ b/bin/templates/cordova/version
@@ -19,13 +19,15 @@
     under the License.
 */
 
-/*
-    Returns the VERSION of CordovaLib used.
-    Note: it does not work if the --shared option was used to create the project.
-*/
+let VERSION = 'version undefined';
 
-// Coho updates this line
-const VERSION = '1.0.0-dev';
+try {
+    const platformPkgPath = require.resolve('cordova-electron/package.json');
+    const platformPkg = require(platformPkgPath) || null;
+    VERSION = platformPkg.version || VERSION;
+} catch (e) {
+    // Do nothing.
+}
 
 module.exports.version = VERSION;
 


### PR DESCRIPTION
### Motivation and Context
`cordova platform ls`  =>  does not reflect the correct version. 

coho is suppose to update this files version but seems to not be configured for Electron properly.

### Description
This PR is to fetch the version from `package.json` instead of having coho update this file.

### Testing
- `cordova platform ls`
- `npm t`

### Checklist
- [x] I've run the tests to see all new and existing tests pass