### PR TITLE
Load a local HTML file or remote a URL in the BrowserWindow

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -253,13 +253,13 @@ Objects created with `new BrowserWindow` have instance methods, one of such is `
 By default, `loadURL` loads a local HTML file which should be defined in `config.xml` under `content` tag.
 The `content` tag value can be a remote address (e.g. `http://`) or a path to a local HTML file using the `file://` protocol.
 
-However, it is also possible to override this option in the Electron settings file.
+For Cordova Electron only: It is possible to override this option from the Electron settings file which additionally provides more options.
 
 > Learn more about [loadURL - BrowserWindow Instance Method](https://electronjs.org/docs/api/browser-window#winloadurlurl-options).
 
-#### Load a local HTML file using relative path to the `{project_dir}/www` folder
+#### Load a local HTML file using relative path from the `{project_dir}/www` directory
 
-To load a local HTML file, place your HTML file in the `{project_dir}/www` folder and define desired to load HTML file in the Electron settings file.
+To override the local HTML file, place your HTML file anywhere in the `{project_dir}/www` directory and define the path in the Electron settings file.
 
  **Example**
 ```json
@@ -272,7 +272,7 @@ To load a local HTML file, place your HTML file in the `{project_dir}/www` folde
 
 #### Load a local HTML using full path
 
-To load a local HTML file using full path, define a full path to the HTML file in the Electron settings file.
+To override the local HTML file using a full path, define the location of the local HTML file in the Electron settings file.
 
  **Example**
 ```json
@@ -287,7 +287,7 @@ To load a local HTML file using full path, define a full path to the HTML file i
 
 #### Load a remote URL
 
-To load a remote address, define desired to load `url` in the Electron settings file.
+To load a remote address, define the `url` in the Electron settings file.
 
  **Example**
 ```json
@@ -298,7 +298,7 @@ To load a remote address, define desired to load `url` in the Electron settings 
   }
 ```
 
-It is also possible to supply an optional `options` object.
+It is also possible to supply additional parameters using the [optional] `options` argument.
 
  **Example**
 ```json

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -251,6 +251,7 @@ Set the `nodeIntegration` flag property to `true`.  By default, this property fl
 Objects created with `new BrowserWindow` have instance methods, one of such is `loadURL`.
 
 By default, `loadURL` loads a local HTML file which should be defined in `config.xml` under `content` tag.
+The `content` tag value can be a remote address (e.g. `http://`) or a path to a local HTML file using the `file://` protocol.
 
 However, it is also possible to override this option in the Electron settings file.
 
@@ -258,13 +259,12 @@ However, it is also possible to override this option in the Electron settings fi
 
 #### Load a local HTML file using relative path to the `{project_dir}/www` folder
 
-To load a local HTML file, place your HTML file in the `{project_dir}/www` folder, set `loadURL.type` to `remote` and define desired to load HTML file in the Electron settings file.
+To load a local HTML file, place your HTML file in the `{project_dir}/www` folder and define desired to load HTML file in the Electron settings file.
 
  **Example**
 ```json
   "browserWindowInstance": {
     "loadURL": {
-      "type": "local",
       "url": "custom.html"
     }
   }
@@ -272,7 +272,7 @@ To load a local HTML file, place your HTML file in the `{project_dir}/www` folde
 
 #### Load a local HTML using full path
 
-To load a local HTML file using full path, place your HTML file in the anywhere you would like folder and define a full path to the HTML file in the Electron settings file.
+To load a local HTML file using full path, define a full path to the HTML file in the Electron settings file.
 
  **Example**
 ```json
@@ -283,17 +283,16 @@ To load a local HTML file using full path, place your HTML file in the anywhere 
   }
 ```
 
-> Do not set `loadURL.type` to `local` in this case. We interpret `loadURL.type` of `local` as a file path relative to the `{project_dir}/www` folder.
+
 
 #### Load a remote URL
 
-To load a remote URL, set `loadURL.type` to `remote` (optional) and define desired to load `url` in the Electron settings file.
+To load a remote address, define desired to load `url` in the Electron settings file.
 
  **Example**
 ```json
   "browserWindowInstance": {
     "loadURL": {
-      "type": "remote",
       "url": "https://cordova.apache.org"
     }
   }
@@ -305,7 +304,6 @@ It is also possible to supply an optional `options` object.
 ```json
   "browserWindowInstance": {
     "loadURL": {
-      "type": "remote",
       "url": "https://cordova.apache.org",
       "options": {
         "extraHeaders": "Content-Type: text/html"

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -174,13 +174,14 @@ Working with a Cordova project, it is recommended to create an Electron settings
 </platform>
 ```
 
-To override or set any BrowserWindow options, in this file the options are added to the  `browserWindow` property.
+To override or set any BrowserWindow options or supply arguments to the loadURL method (BrowserWindow instance method), in this file the options are added to the `browserWindow` or `browserWindowInstance` property accordingly.
 
 **Example `res/electron/settings.json`:**
 
 ```json
 {
-    "browserWindow": { ... }
+    "browserWindow": { ... },
+    "browserWindowInstance": { ... }
 }
 ```
 
@@ -244,6 +245,76 @@ Set the `nodeIntegration` flag property to `true`.  By default, this property fl
     }
 }
 ```
+
+### Customizing BrowserWindow Instance Method
+
+Objects created with `new BrowserWindow` have instance methods, one of such is `loadURL`.
+
+By default, `loadURL` loads a local HTML file which should be defined in `config.xml` under `content` tag.
+
+However, it is also possible to override this option in the Electron settings file.
+
+> Learn more about [loadURL - BrowserWindow Instance Method](https://electronjs.org/docs/api/browser-window#winloadurlurl-options).
+
+#### Load a local HTML file using relative path to the `{project_dir}/www` folder
+
+To load a local HTML file, place your HTML file in the `{project_dir}/www` folder, set `loadURL.type` to `remote` and define desired to load HTML file in the Electron settings file.
+
+ **Example**
+```json
+  "browserWindowInstance": {
+    "loadURL": {
+      "type": "local",
+      "url": "custom.html"
+    }
+  }
+```
+
+#### Load a local HTML using full path
+
+To load a local HTML file using full path, place your HTML file in the anywhere you would like folder and define a full path to the HTML file in the Electron settings file.
+
+ **Example**
+```json
+  "browserWindowInstance": {
+    "loadURL": {
+      "url": "file://{full_path}/index.html"
+    }
+  }
+```
+
+> Do not set `loadURL.type` to `local` in this case. We interpret `loadURL.type` of `local` as a file path relative to the `{project_dir}/www` folder.
+
+#### Load a remote URL
+
+To load a remote URL, set `loadURL.type` to `remote` (optional) and define desired to load `url` in the Electron settings file.
+
+ **Example**
+```json
+  "browserWindowInstance": {
+    "loadURL": {
+      "type": "remote",
+      "url": "https://cordova.apache.org"
+    }
+  }
+```
+
+It is also possible to supply an optional `options` object.
+
+ **Example**
+```json
+  "browserWindowInstance": {
+    "loadURL": {
+      "type": "remote",
+      "url": "https://cordova.apache.org",
+      "options": {
+        "extraHeaders": "Content-Type: text/html"
+      }
+    }
+  }
+```
+
+> For more information refer to [Electron documentation](https://electronjs.org/docs/api/browser-window#winloadurlurl-options).
 
 ## Customizing the Electron's Main Process
 

--- a/bin/templates/cordova/lib/SettingJsonParser.js
+++ b/bin/templates/cordova/lib/SettingJsonParser.js
@@ -28,19 +28,15 @@ class SettingJsonParser {
     }
 
     configure (config, options, userElectronSettingsPath) {
-        // Set loadURL path from config.xml.
-        const url = config.doc.find('content').attrib.src;
-        if (url) {
-            this.package.browserWindowInstance = {
-                loadURL: {
-                    url: url
-                }
-            };
+        // Set loadURL path from config.xml or fallback to index.html
+        const contentNode = config.doc.find('content');
+        const contentSrc = (contentNode && contentNode.attrib.src) || 'index.html';
 
-            if (!url.includes('://')) {
-                this.package.browserWindowInstance.loadURL.type = 'local';
+        this.package.browserWindowInstance = {
+            loadURL: {
+                url: contentSrc
             }
-        }
+        };
 
         // Apply user settings ontop of defaults.
         if (userElectronSettingsPath) {

--- a/bin/templates/cordova/lib/SettingJsonParser.js
+++ b/bin/templates/cordova/lib/SettingJsonParser.js
@@ -27,15 +27,29 @@ class SettingJsonParser {
         this.package = require(this.path);
     }
 
-    configure (config, userElectronSettingsPath) {
+    configure (config, options, userElectronSettingsPath) {
+        // Set loadURL path from config.xml.
+        const url = config.doc.find('content').attrib.src;
+        if (url) {
+            this.package.browserWindowInstance = {
+                loadURL: {
+                    url: url
+                }
+            };
+
+            if (!url.includes('://')) {
+                this.package.browserWindowInstance.loadURL.type = 'local';
+            }
+        }
+
         // Apply user settings ontop of defaults.
         if (userElectronSettingsPath) {
             const userElectronSettings = require(userElectronSettingsPath);
             this.package = deepMerge(this.package, userElectronSettings);
         }
 
-        if (config) {
-            this.package.browserWindow.webPreferences.devTools = !config.release;
+        if (options) {
+            this.package.browserWindow.webPreferences.devTools = !options.release;
         }
 
         return this;

--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -86,7 +86,7 @@ module.exports.prepare = function (cordovaProject, options) {
 
     // update Electron settings in .json file
     (new SettingJsonParser(this.locations.www))
-        .configure(options.options, userElectronSettingsPath)
+        .configure(this.config, options.options, userElectronSettingsPath)
         .write();
 
     // update project according to config.xml changes.

--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -41,12 +41,15 @@ function createWindow () {
     const browserWindowOpts = Object.assign({}, cdvElectronSettings.browserWindow, { icon: appIcon });
     mainWindow = new BrowserWindow(browserWindowOpts);
 
-    // and load the index.html of the app.
-    // TODO: possibly get this data from config.xml
-    mainWindow.loadURL(`file://${__dirname}/index.html`);
-    mainWindow.webContents.on('did-finish-load', function () {
-        mainWindow.webContents.send('window-id', mainWindow.id);
-    });
+    // Load a local HTML file or a remote URL.
+    const loadURLOpts = Object.assign({}, cdvElectronSettings.browserWindowInstance.loadURL.options);
+    if (!cdvElectronSettings.browserWindowInstance.loadURL.type || cdvElectronSettings.browserWindowInstance.loadURL.type === 'remote') {
+        mainWindow.loadURL(cdvElectronSettings.browserWindowInstance.loadURL.url, loadURLOpts);
+    } else if (cdvElectronSettings.browserWindowInstance.loadURL.type === 'local') {
+        mainWindow.loadURL(`file://${__dirname}/${cdvElectronSettings.browserWindowInstance.loadURL.url}`, loadURLOpts);
+    } else {
+        mainWindow.loadURL(`file://${__dirname}/index.html`);
+    }
 
     // Open the DevTools.
     if (cdvElectronSettings.browserWindow.webPreferences.devTools) {

--- a/bin/templates/project/cdv-electron-main.js
+++ b/bin/templates/project/cdv-electron-main.js
@@ -42,14 +42,11 @@ function createWindow () {
     mainWindow = new BrowserWindow(browserWindowOpts);
 
     // Load a local HTML file or a remote URL.
-    const loadURLOpts = Object.assign({}, cdvElectronSettings.browserWindowInstance.loadURL.options);
-    if (!cdvElectronSettings.browserWindowInstance.loadURL.type || cdvElectronSettings.browserWindowInstance.loadURL.type === 'remote') {
-        mainWindow.loadURL(cdvElectronSettings.browserWindowInstance.loadURL.url, loadURLOpts);
-    } else if (cdvElectronSettings.browserWindowInstance.loadURL.type === 'local') {
-        mainWindow.loadURL(`file://${__dirname}/${cdvElectronSettings.browserWindowInstance.loadURL.url}`, loadURLOpts);
-    } else {
-        mainWindow.loadURL(`file://${__dirname}/index.html`);
-    }
+    const cdvUrl = cdvElectronSettings.browserWindowInstance.loadURL.url;
+    const loadUrl = cdvUrl.includes('://') ? cdvUrl : `file://${__dirname}/${cdvUrl}`;
+    const loadUrlOpts = Object.assign({}, cdvElectronSettings.browserWindowInstance.loadURL.options);
+
+    mainWindow.loadURL(loadUrl, loadUrlOpts);
 
     // Open the DevTools.
     if (cdvElectronSettings.browserWindow.webPreferences.devTools) {

--- a/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
@@ -20,6 +20,14 @@
 const rewire = require('rewire');
 const path = require('path');
 
+const ConfigParser = require('cordova-common').ConfigParser;
+
+const FIXTURES = path.join(__dirname, '..', '..', '..', '..', 'fixtures');
+
+// Create a real config object before mocking out everything.
+const cfg = new ConfigParser(path.join(FIXTURES, 'test-config-1.xml'));
+const cfgEmpty = new ConfigParser(path.join(FIXTURES, 'test-config-empty.xml'));
+
 describe('Testing SettingJsonParser.js:', () => {
     let SettingJsonParser;
     let locations;
@@ -67,7 +75,7 @@ describe('Testing SettingJsonParser.js:', () => {
             expect(settingJsonParser.package).toEqual({});
         });
 
-        it('should use default when users settings files does not exist, but set devTools value from options', () => {
+        it('should use default when users settings files does not exist and config.xml is empty, but set devTools value from options', () => {
             options = { options: { release: true, argv: [] } };
 
             SettingJsonParser.__set__('require', (file) => {
@@ -86,7 +94,7 @@ describe('Testing SettingJsonParser.js:', () => {
                 return require(file);
             });
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, false);
+            settingJsonParser = new SettingJsonParser(locations.www).configure(cfgEmpty, options.options, false);
 
             expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(false);
             expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(true);
@@ -111,7 +119,7 @@ describe('Testing SettingJsonParser.js:', () => {
                 return require(file);
             });
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, false);
+            settingJsonParser = new SettingJsonParser(locations.www).configure(cfg, options.options, false);
 
             expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(true);
             expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(true);
@@ -147,7 +155,7 @@ describe('Testing SettingJsonParser.js:', () => {
                 return require(file);
             });
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA');
+            settingJsonParser = new SettingJsonParser(locations.www).configure(cfg, options.options, 'LOAD_MY_FAKE_DATA');
 
             expect(settingJsonParser.package.browserWindow.webPreferences.devTools).toBe(true);
             expect(settingJsonParser.package.browserWindow.webPreferences.nodeIntegration).toBe(false);
@@ -177,14 +185,14 @@ describe('Testing SettingJsonParser.js:', () => {
                 return require(file);
             });
 
-            settingJsonParser = new SettingJsonParser(locations.www).configure(options.options, 'LOAD_MY_FAKE_DATA').write();
+            settingJsonParser = new SettingJsonParser(locations.www).configure(cfg, options.options, 'LOAD_MY_FAKE_DATA').write();
 
             expect(writeFileSyncSpy).toHaveBeenCalled();
 
             // get settings json file content and remove white spaces
             let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
             settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual(`{"browserWindow":{"webPreferences":{"devTools":true,"nodeIntegration":true}}}`);
+            expect(settingsFile).toEqual(`{"browserWindow":{"webPreferences":{"devTools":true,"nodeIntegration":true}},"browserWindowInstance":{"loadURL":{"url":"index.html","type":"local"}}}`);
 
             const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
             expect(settingsFormat).toEqual('utf8');

--- a/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/SettingJsonParser.spec.js
@@ -192,7 +192,7 @@ describe('Testing SettingJsonParser.js:', () => {
             // get settings json file content and remove white spaces
             let settingsFile = writeFileSyncSpy.calls.argsFor(0)[1];
             settingsFile = settingsFile.replace(/\s+/g, '');
-            expect(settingsFile).toEqual(`{"browserWindow":{"webPreferences":{"devTools":true,"nodeIntegration":true}},"browserWindowInstance":{"loadURL":{"url":"index.html","type":"local"}}}`);
+            expect(settingsFile).toEqual(`{"browserWindow":{"webPreferences":{"devTools":true,"nodeIntegration":true}},"browserWindowInstance":{"loadURL":{"url":"index.html"}}}`);
 
             const settingsFormat = writeFileSyncSpy.calls.argsFor(0)[2];
             expect(settingsFormat).toEqual('utf8');

--- a/tests/spec/unit/templates/cordova/lib/prepare.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/prepare.spec.js
@@ -178,8 +178,8 @@ class FakePackageJsonParser extends FakeParser {
 }
 
 class FakeSettingJsonParser extends FakeParser {
-    configure (options, userElectronFile) {
-        fakeSettingJsonParserConfigureSpy(options, userElectronFile);
+    configure (configXmlParser, options, userElectronFile) {
+        fakeSettingJsonParserConfigureSpy(configXmlParser, options, userElectronFile);
         return this;
     }
 }
@@ -272,7 +272,7 @@ describe('Testing prepare.js:', () => {
             });
         });
 
-        it('should get user supplied Electron settings overide path from config.xml but iggnore for incorrect path.', () => {
+        it('should get user supplied Electron settings overide path from config.xml but ignore for incorrect path.', () => {
             // Mocking the scope with dummy API;
             return Promise.resolve().then(function () {
                 // Create API instance and mock for test case.
@@ -358,7 +358,7 @@ describe('Testing prepare.js:', () => {
                 expect(fakeManifestJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakePackageJsonParserConfigureSpy).toHaveBeenCalled();
                 expect(fakeSettingJsonParserConfigureSpy).toHaveBeenCalled();
-                const actual = fakeSettingJsonParserConfigureSpy.calls.argsFor(0)[1];
+                const actual = fakeSettingJsonParserConfigureSpy.calls.argsFor(0)[2];
                 expect(actual).toContain('pass_test_path');
             });
         });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #80 

### Description
<!-- Describe your changes in detail -->

Objects created with `new BrowserWindow` have instance methods, one of such is `loadURL`. Previously we have loaded `{project_dir}/www/index.html` file explicitly. This PR adds an ability to change the start page.

- By default, `loadURL` loads a local HTML file which should be defined in `config.xml` under `content` tag.
- Possible to override this option in the Electron settings file. (More info in the `DOCUMENTATION.md`)

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t` 

Manually tested with the following Electron settings files:

```json
  "browserWindowInstance": {
    "loadURL": {
      "url": "custom.html"
    }
  }
```

```json
  "browserWindowInstance": {
    "loadURL": {
      "url": "https://cordova.apache.org"
    }
  }
```

```json
  "browserWindowInstance": {
    "loadURL": {
      "url": "https://cordova.apache.org",
      "options": {
        "extraHeaders": "text/html"
      }
    }
  }
```

In case if `config.xml` does not have a `content` tag with a `src` defined and there is no custom configuration for `browserWindowInstance`, `loadURL` tries to load `{project_dir}/www/index.html`.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- ~~[ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary