### PR TITLE
Add fallback to nodejs require method in order to use nodejs module

### DIFF
--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -18,7 +18,7 @@
  specific language governing permissions and limitations
  under the License.
 */
-;(function() {
+;(function(nodejsRequire) {
 var PLATFORM_VERSION_BUILD_LABEL = '1.2.0-dev';
 // file: src/scripts/require.js
 
@@ -51,7 +51,12 @@ var define;
 
     require = function (id) {
         if (!modules[id]) {
-            throw 'module ' + id + ' not found';
+            // use original nodejs require if modules not existing in codova
+            if(nodejsRequire){
+                return nodejsRequire(id);
+            }else{
+                throw 'module ' + id + ' not found';
+            }
         } else if (id in inProgressModules) {
             var cycle = requireStack.slice(inProgressModules[id]).join('->') + '->' + id;
             throw 'Cycle in require graph: ' + cycle;
@@ -1610,4 +1615,4 @@ window.cordova = require('cordova');
 
 require('cordova/init');
 
-})();
+})(require);


### PR DESCRIPTION
Add fallback to nodejs require method in order to use nodejs module in electron plugin

### Platforms affected
Electron

### Motivation and Context
Allow using nodejs 'require' method to load nodejs module inside electron platform plugin

### Description
Add fallback to nodejs require method in order to use nodejs module in electron plugin

### Testing
Create an electron plugin that require nodejs module inside, add it to a sample cordova project and check that plugin works and uses nodejs module

### Checklist

- [x] I've run the tests to see all new and existing tests pass
~~- [ ] I added automated test coverage as appropriate for this change~~
~~- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
~~- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
~~- [ ] I've updated the documentation if necessary~~
