### PR TITLE
fix: use spyOn for process global var

### DIFF
--- a/tests/spec/unit/templates/cordova/lib/build.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/build.spec.js
@@ -43,6 +43,7 @@ describe('Testing build.js:', () => {
             ElectronBuilder = build.__get__('ElectronBuilder');
 
             build.__set__({ require: requireSpy });
+            spyOn(process, 'env');
 
             emitSpy = jasmine.createSpy('emit');
             build.__set__('events', { emit: emitSpy });
@@ -1355,7 +1356,7 @@ describe('Testing build.js:', () => {
             };
 
             // set process.env.CSC_LINK
-            build.__set__('process', Object.assign({}, { env: { CSC_LINK: 'csc_link' } }));
+            process.env.CSC_LINK = 'csc_link';
 
             // create spies
             existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(false);
@@ -1418,7 +1419,7 @@ describe('Testing build.js:', () => {
             };
 
             // set process.env.CSC_NAME
-            build.__set__('process', Object.assign({}, { env: { CSC_NAME: 'csc_name' } }));
+            process.env.CSC_NAME = 'csc_name';
 
             // create spies
             existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(false);
@@ -1528,7 +1529,7 @@ describe('Testing build.js:', () => {
             };
 
             // set process.env.CSC_KEY_PASSWORD
-            build.__set__('process', Object.assign({}, { env: { CSC_KEY_PASSWORD: 'csc_key_password' } }));
+            process.env.CSC_KEY_PASSWORD = 'csc_key_password';
 
             // create spies
             existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
@@ -1645,7 +1646,6 @@ describe('Testing build.js:', () => {
             const expectedAdditionalCertificateFile = 'The provided addition certificate file does not exist';
             expect(actualAdditionalCertificateFile).toContain(expectedAdditionalCertificateFile);
         });
-
         it('should call build method.', () => {
             // mock buildOptions Objecet
             const buildOptions = { debug: true, buildConfig: 'build.xml', argv: [] };

--- a/tests/spec/unit/templates/cordova/lib/clean.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/clean.spec.js
@@ -23,19 +23,16 @@ const clean = rewire('../../../../../../bin/templates/cordova/lib/clean');
 describe('Clean', () => {
     describe('run export method', () => {
         it('should stop process when requirement check fails.', () => {
-            // get original
-            const _process = clean.__get__('process');
-
             // create spies
             const logSpy = jasmine.createSpy('log');
-            const exitSpy = jasmine.createSpy('exit');
 
             // set spies
             clean.__set__('console', { error: logSpy });
             clean.__set__('check_reqs', {
                 run: jasmine.createSpy('run').and.returnValue(false)
             });
-            clean.__set__('process', { exit: exitSpy });
+
+            spyOn(process, 'exit');
 
             // run test
             clean.run();
@@ -44,10 +41,7 @@ describe('Clean', () => {
             const expectedLog = 'Please make sure you meet the software requirements in order to clean an electron cordova project';
 
             expect(logArgs).toContain(expectedLog);
-            expect(exitSpy).toHaveBeenCalledWith(2);
-
-            // Reset
-            clean.__set__('process', _process);
+            expect(process.exit).toHaveBeenCalledWith(2);
         });
 
         it('should not find previous build dir and not attempt to remove.', () => {

--- a/tests/spec/unit/templates/cordova/lib/run.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/run.spec.js
@@ -24,16 +24,12 @@ const run = rewire('../../../../../../bin/templates/cordova/lib/run');
 describe('Run', () => {
     describe('run export method', () => {
         it('should spawn electron with cdv-electron-main.js.', () => {
-            const _process = run.__get__('process');
             const spawnSpy = jasmine.createSpy('spawn');
             const onSpy = jasmine.createSpy('on');
-            const exitSpy = jasmine.createSpy('exit');
             const expectedPathToMain = path.resolve(__dirname, '..', '..', '..', '..', '..', '..', 'bin', 'templates', 'www', 'cdv-electron-main.js');
 
             run.__set__('electron', 'electron-require');
-            run.__set__('process', {
-                exit: exitSpy
-            });
+            spyOn(process, 'exit');
 
             run.__set__('proc', {
                 spawn: spawnSpy.and.returnValue({
@@ -45,13 +41,11 @@ describe('Run', () => {
 
             expect(spawnSpy).toHaveBeenCalledWith('electron-require', [expectedPathToMain]);
             expect(onSpy).toHaveBeenCalled();
-            expect(exitSpy).not.toHaveBeenCalled();
+            expect(process.exit).not.toHaveBeenCalled();
 
             // trigger exist as if process was killed
             onSpy.calls.argsFor(0)[1]();
-            expect(exitSpy).toHaveBeenCalled();
-
-            run.__set__('process', _process);
+            expect(process.exit).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
### Motivation and Context
Code coverage displayed inaccurate results for node 12 because rewiring process was not working.

### Description
Applied spyOn to rewire the global process sub properties such as  `exit`, `env` etc.

### Testing
- `npm t`
- [Travis CI](https://travis-ci.org/erisu/cordova-electron/builds/557721740)

### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change