### PR TITLE
refactor: improve create test spec speed

### DIFF
--- a/tests/spec/unit/create.spec.js
+++ b/tests/spec/unit/create.spec.js
@@ -71,7 +71,7 @@ function createAndValidateProjectDirName (projectname, projectid) {
         copySync: () => true
     });
 
-    create.createProject(projectPath, projectname, projectid, projectname)
+    return create.createProject(projectPath, projectname, projectid, projectname)
         .then(() => {
             // expects the project name to be the directory name.
             expect(_fs.readdirSync(tmpDir).includes(projectname)).toBe(true);
@@ -97,42 +97,42 @@ describe('create', () => {
         const projectname = 'testcreate';
         const projectid = 'com.test.app1';
 
-        createAndValidateProjectDirName(projectname, projectid);
+        return createAndValidateProjectDirName(projectname, projectid);
     });
 
     it('create project with ascii name, and spaces', () => {
         const projectname = 'test create';
         const projectid = 'com.test.app2';
 
-        createAndValidateProjectDirName(projectname, projectid);
+        return createAndValidateProjectDirName(projectname, projectid);
     });
 
     it('create project with unicode name, no spaces', () => {
         const projectname = '応応応応用用用用';
         const projectid = 'com.test.app3';
 
-        createAndValidateProjectDirName(projectname, projectid);
+        return createAndValidateProjectDirName(projectname, projectid);
     });
 
     it('create project with unicode name, and spaces', () => {
         const projectname = '応応応応 用用用用';
         const projectid = 'com.test.app4';
 
-        createAndValidateProjectDirName(projectname, projectid);
+        return createAndValidateProjectDirName(projectname, projectid);
     });
 
     it('create project with ascii+unicode name, no spaces', () => {
         const projectname = '応応応応hello用用用用';
         const projectid = 'com.test.app5';
 
-        createAndValidateProjectDirName(projectname, projectid);
+        return createAndValidateProjectDirName(projectname, projectid);
     });
 
     it('create project with ascii+unicode name, and spaces', () => {
         const projectname = '応応応応 hello 用用用用';
         const projectid = 'com.test.app6';
 
-        createAndValidateProjectDirName(projectname, projectid);
+        return createAndValidateProjectDirName(projectname, projectid);
     });
 
     it('should stop creating project when project destination already exists', () => {


### PR DESCRIPTION
### Motivation and Context
Speed up the tests.

### Description
Currently, the tests run a create and build step of various projects with various names. (ASCII and Unicode combinations).

Since Electron never supported the platform-centric workflow, these binaries do not work. For example `create` and `version` will work but `run` and `build` fails.

Since there is no current plan for platform-centric workflow in the Cordova Electron platform, it is not necessary to test these.

Instead, I kept one create the test with a verify step that ensures the binaries are copied to the right locations.

Second, for the various name tests, I used the create API to create an empty folder with the name and verified the folder name.

If we decide that its better to remove these un-used binaries and remove the tests altogether, we can do this in a major release as it will remove code even-though the code was broken.

### Testing
- `npm t`
- [Travis CI](https://travis-ci.org/erisu/cordova-electron/builds/559829179)
  - For a speed comparison you can see the last run on [Apache's Travis CI](https://travis-ci.org/apache/cordova-electron/builds/559828467)

### Checklist
- [x] I've run the tests to see all new and existing tests pass
