### PR TITLE
fix: prepare missing dependencies failure

### DIFF
--- a/bin/templates/cordova/lib/PackageJsonParser.js
+++ b/bin/templates/cordova/lib/PackageJsonParser.js
@@ -37,22 +37,24 @@ class PackageJsonParser {
             this.package.version = config.version() || '1.0.0';
             this.package.description = config.description() || 'A sample Apache Cordova application that responds to the deviceready event.';
 
-            const cordovaDependencies = Object.keys(projectPackageJson.dependencies)
-                .filter((npmPackage) => /^cordova(?!-plugin)-/.test(npmPackage));
+            if (projectPackageJson.dependencies) {
+                const cordovaDependencies = Object.keys(projectPackageJson.dependencies)
+                    .filter((npmPackage) => /^cordova(?!-plugin)-/.test(npmPackage));
 
-            // If Cordova dependencies are detected in "dependencies" of "package.json" warn for potential app package bloating
-            if (cordovaDependencies.length) {
-                events.emit('warn', '[Cordova Electron] The built package size may be larger than necessary. Please run with --verbose for more details.');
+                // If Cordova dependencies are detected in "dependencies" of "package.json" warn for potential app package bloating
+                if (cordovaDependencies.length) {
+                    events.emit('warn', '[Cordova Electron] The built package size may be larger than necessary. Please run with --verbose for more details.');
 
-                events.emit('verbose', `[Cordova Electron] The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
+                    events.emit('verbose', `[Cordova Electron] The following Cordova package(s) were detected as "dependencies" in the projects "package.json" file.
 \t- ${cordovaDependencies.join('\n\t- ')}
 
 It is recommended that all Cordova packages are defined as "devDependencies" in the "package.json" file. It is safe to move them manually.
 Packages defined as a dependency will be bundled with the application and can increase the built application's size.
 `);
-            }
+                }
 
-            this.package.dependencies = projectPackageJson.dependencies;
+                this.package.dependencies = projectPackageJson.dependencies;
+            }
 
             this.configureHomepage(config);
             this.configureLicense(config);

--- a/tests/spec/unit/templates/cordova/lib/PackageJsonParser.spec.js
+++ b/tests/spec/unit/templates/cordova/lib/PackageJsonParser.spec.js
@@ -155,6 +155,17 @@ describe('PackageJsonParser class', () => {
         expect(emitSpy).not.toHaveBeenCalled();
     });
 
+    it('should not set package dependencies when project dependencies is missing.', () => {
+        let mockProjectPackageJson = Object.assign({}, defaultMockProjectPackageJson);
+        mockProjectPackageJson.devDependencies = Object.assign({}, defaultMockProjectPackageJson.dependencies);
+        delete mockProjectPackageJson.dependencies;
+
+        packageJsonParser = new PackageJsonParser(locations.www).configure(cfg, mockProjectPackageJson);
+
+        expect(emitSpy).not.toHaveBeenCalled();
+        expect(packageJsonParser.package.dependencies).not.toBeDefined();
+    });
+
     it('should write provided data when config xml is empty.', () => {
         const writeFileSyncSpy = jasmine.createSpy('writeFileSync');
         packageJsonParser.__set__('fs', { writeFileSync: writeFileSyncSpy });


### PR DESCRIPTION
### Motivation and Context
fixes: #87 

### Description
The code tries to read the `dependencies` property from the `package.json` and is expected to be an `object`. Since the property in this case did not exist, it is `undefined` and the code there after fails.

I have added a wrapper to check if the `dependencies` property exists before continuing.

### Testing
- `npm t`

### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))