### PR TITLE
chore: configure app rel dependencies as abs paths

### DIFF
--- a/bin/templates/cordova/lib/prepare.js
+++ b/bin/templates/cordova/lib/prepare.js
@@ -74,7 +74,7 @@ module.exports.prepare = function (cordovaProject, options) {
 
     const projectPackageJson = JSON.parse(fs.readFileSync(path.join(cordovaProject.root, 'package.json'), 'utf8'));
 
-    (new PackageJsonParser(this.locations.www))
+    (new PackageJsonParser(this.locations.www, cordovaProject.root))
         .configure(this.config, projectPackageJson)
         .write();
 


### PR DESCRIPTION
### Motivation and Context

Build fails when the `package.json` contains a dependency that is from the local file system and is a relative path.

### Description

This PR adds to the prepare step for the App's `package.json` to convert relative paths to absolute paths. If the converted path does not exist, it will be drop from being added to the App's `package.json` and a warning is displayed.

### Testing

- `npm t`
- platform add, prepare, and build

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
