### PR TITLE
fix(npm-script): prepack

### DIFF
--- a/.npm-scripts/prepack.js
+++ b/.npm-scripts/prepack.js
@@ -1,5 +1,5 @@
 const { resolve } = require('path');
-const { copyFileSync } = require('fs-extra');
+const { copyFileSync } = require('fs');
 
 // copy cordova.js to bin/templates/project
 copyFileSync(resolve('cordova-lib/cordova.js'), resolve('bin/templates/platform_www/cordova.js'));


### PR DESCRIPTION
### Motivation and Context

Nightly builds are broken because of npm dependency is not available.

### Description

As the nightly build system does not run `npm i`, the `fs-extra` dependency does not exist. Instead of updating the build system, I decided to use nodes native `fs` implementation.

### Testing

`npm pack`
