### PR TITLE
Proposed Feature: Load DevToolExtensions from electron configuration

### DIFF
--- a/bin/templates/platform_www/cdv-electron-main.js
+++ b/bin/templates/platform_www/cdv-electron-main.js
@@ -51,6 +51,11 @@ function createWindow () {
     // Open the DevTools.
     if (cdvElectronSettings.browserWindow.webPreferences.devTools) {
         mainWindow.webContents.openDevTools();
+
+        // add dev tool extensions
+        cdvElectronSettings.devToolExtensions.forEach((extensionPath) => {
+            BrowserWindow.addDevToolsExtension(extensionPath);
+        });
     }
 
     // Emitted when the window is closed.


### PR DESCRIPTION
Hi I'd like to extend the electron configuration, but I'd like to get some feedback on the changes before writing tests, etc.

### Platforms affected
Unsure


### Motivation and Context

Electron provides a method for [loading chrome development tools extensions](https://www.electronjs.org/docs/tutorial/devtools-extension) into the Browser window. This is currently not possible 


### Description
I'd like to extend the configuration format to include a set of dev tool extensions. The format I'm using on my fork looks like the following:

```json
{
  "browserWindow": {
    "width": 1024,
    "height": 768
  },
  "devToolExtensions": [
    "[Path/To/Home/Directory]/.config/google-chrome/Default/Extensions/fmkadmapgofadopljbjfkapdkoienihi/4.4.0_0"
  ]
}
```
The above loads React Dev tools into the electron build.


### Testing




### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
