### PR TITLE
test (node-12.16.x): fix failures caused by shebang and rewire lint

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file

--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -82,7 +82,7 @@ class Api {
             locations: this.locations,
             root: this.root,
             name: this.platform,
-            version: require('./version'),
+            version: Api.version(),
             projectConfig: this.config
         };
     }
@@ -341,6 +341,20 @@ class Api {
 
     requirements () {
         return require('./lib/check_reqs').run();
+    }
+
+    static version () {
+        let platformPkg = null;
+
+        try {
+            // coming from user project
+            platformPkg = require(require.resolve('cordova-electron/package.json'));
+        } catch (e) {
+            // coming from repo test & coho
+            platformPkg = require('../../../package.json');
+        }
+
+        return platformPkg.version;
     }
 }
 // @todo create projectInstance and fulfill promise with it.

--- a/bin/templates/cordova/version
+++ b/bin/templates/cordova/version
@@ -19,16 +19,5 @@
     under the License.
 */
 
-let VERSION = 'version undefined';
-
-try {
-    const platformPkgPath = require.resolve('cordova-electron/package.json');
-    const platformPkg = require(platformPkgPath) || null;
-    VERSION = platformPkg.version || VERSION;
-} catch (e) {
-    // Do nothing.
-}
-
-module.exports.version = VERSION;
-
-if (!module.parent) console.log(VERSION);
+const Api = require('./Api');
+console.log(Api.version());

--- a/tests/spec/unit/Api.spec.js
+++ b/tests/spec/unit/Api.spec.js
@@ -99,8 +99,7 @@ describe('Api class', () => {
 
     describe('getPlatformInfo method', () => {
         it('should return object containing platform information', () => {
-            // Mocking require that is called to get version.
-            Api.__set__('require', () => '1.0.0');
+            spyOn(Api, 'version').and.returnValue('1.0.0');
 
             expect(api.getPlatformInfo()).toEqual({
                 locations: mockExpectedLocations,
@@ -109,8 +108,6 @@ describe('Api class', () => {
                 version: '1.0.0',
                 projectConfig: undefined
             });
-
-            Api.__set__('require', apiRequire);
         });
     });
 
@@ -454,6 +451,38 @@ describe('Api prototype methods', () => {
         it('should emit createPlatform not callable when error occurs.', () => {
             spyOn(create, 'createProject').and.returnValue(new Error('Some Random Error'));
             expect(() => Api.createPlatform(tmpDir)).toThrowError();
+        });
+    });
+
+    describe('version method', () => {
+        it('should get version from cordova-electron package.', () => {
+            const dummyRequire = path => {
+                expect(path).toEqual('cordova-elecrtron-resolved-package-path');
+                return { version: '1.0.0' };
+            };
+
+            dummyRequire.resolve = path => {
+                return 'cordova-elecrtron-resolved-package-path';
+            };
+
+            Api.__set__('require', dummyRequire);
+
+            expect(Api.version()).toEqual('1.0.0');
+        });
+
+        it('should get version from package.json.', () => {
+            const dummyRequire = path => {
+                expect(path).toEqual('../../../package.json');
+                return { version: '1.0.0' };
+            };
+
+            dummyRequire.resolve = path => {
+                throw Error('random error');
+            };
+
+            Api.__set__('require', dummyRequire);
+
+            expect(Api.version()).toEqual('1.0.0');
         });
     });
 });


### PR DESCRIPTION
### Motivation and Context

Fix failing tests that are triggered by the combination of latest node version 12.16.0+, files containing shebang, and rewire linter.

Example Error:
```
SyntaxError: Invalid or unexpected token
    at new Script (vm.js:88:7)
    at createScript (vm.js:263:10)
    at Object.runInThisContext (vm.js:311:10)
    at wrapSafe (internal/modules/cjs/loader.js:1059:15)
    at Module._compile (internal/modules/cjs/loader.js:1122:27)
```

### Description

* Removed shebang from JS files.
* JS files should not load `bin` files with `require`.
  * Moved the `version` logic into `Api.js` and updated the `version` bin file to call `Api.js`

### Testing

- `npm t`
- `cordova platform add`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
