### PR TITLE
feat: support electron arguments on run command

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -358,7 +358,7 @@ The `--release` and `--debug` flags control the visibility of the DevTools. DevT
 
 If you need to debug the application's main process, you can do so by enabling the inspector with the Election's `inspect` or `inspect-brk` flags.
 
-As these flags are provided by Electron, you will need to separate the Cordova flags from Electron flags with and additional `--` separator.
+As these flags are provided by Electron, you will need to separate the Cordova flags from Electron flags with an additional `--` separator.
 
 For example:
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -40,6 +40,7 @@ Electron is a framework that uses web technologies (HTML, CSS, and JS) to build 
   - [Bundling Node Modules](#bundling-node-modules)
     - [Cordova Package Handling](#cordova-package-handling)
   - [DevTools](#devtools)
+  - [Debugging the Application's Main Process](#debugging-the-applications-main-process)
   - [Build Configurations](#build-configurations)
     - [Default Build Configurations](#default-build-configurations)
     - [Customizing Build Configurations](#customizing-build-configurations)
@@ -352,6 +353,18 @@ Packages defined as a dependency will be bundled with the application and can in
 The `--release` and `--debug` flags control the visibility of the DevTools. DevTools are shown by default on **Debug Builds** (`without a flag` or with `--debug`). If you want to hide the DevTools pass in the `--release` flag when building or running the application.
 
 > Note: DevTools can be closed or opened manually with the debug build.
+
+## Debugging the Application's Main Process
+
+If you need to debug the application's main process, you can do so by enabling the inspector with the Election's `inspect` or `inspect-brk` flags.
+
+As these flags are provided by Electron, you will need to separate the Cordova flags from Electron flags with and additional `--` separator.
+
+For example:
+
+```shell
+cordova run electron --nobuild --debug -- --inspect-brk=5858
+```
 
 ## Build Configurations
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -21,9 +21,15 @@ const electron = require('electron');
 const execa = require('execa');
 const path = require('path');
 
-module.exports.run = (args) => {
-    const pathToMain = path.join(global.cdvPlatformPath, 'www/cdv-electron-main.js');
-    const child = execa(electron, [pathToMain]);
+module.exports.run = (args = {}) => {
+    const electonArgs = args.argv || [];
+
+    // Add the path to the main process as the last Electron argument to pass into execa
+    electonArgs.push(
+        path.join(global.cdvPlatformPath, 'www/cdv-electron-main.js')
+    );
+
+    const child = execa(electron, electonArgs);
 
     child.on('close', (code) => {
         process.exit(code);

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -48,6 +48,32 @@ describe('Run', () => {
             onSpy.calls.argsFor(0)[1]();
             expect(process.exit).toHaveBeenCalled();
         });
+
+        it('should pass arguments to electron', () => {
+            const execaSpy = jasmine.createSpy('execa');
+            const onSpy = jasmine.createSpy('on');
+            const expectedElectronArguments = [
+                '--inspect-brk=5858',
+                path.join(rootDir, 'bin/templates/www/cdv-electron-main.js')
+            ];
+
+            run.__set__('electron', 'electron-require');
+            spyOn(process, 'exit');
+
+            run.__set__('execa', execaSpy.and.returnValue({
+                on: onSpy.and.callThrough()
+            }));
+
+            run.run({ argv: ['--inspect-brk=5858'] });
+
+            expect(execaSpy).toHaveBeenCalledWith('electron-require', expectedElectronArguments);
+            expect(onSpy).toHaveBeenCalled();
+            expect(process.exit).not.toHaveBeenCalled();
+
+            // trigger exist as if process was killed
+            onSpy.calls.argsFor(0)[1]();
+            expect(process.exit).toHaveBeenCalled();
+        });
     });
 
     describe('help export method', () => {


### PR DESCRIPTION
### Motivation, Context & Description

Add the ability to pass Electron arguments to the run command.

This feature, for example, can allow users the pass the flag which enabled the ability to debug the main process.

**Example Commands**

* `--inspect=[port]`
* `--inspect-brk=[port]`

**Example Usage**

```shell
cordova run electron --nobuild -- --inspect-brk=5858
```

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] I've updated the documentation if necessary
