### PR TITLE
chore: bump cordova-common 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,9 +1027,9 @@
       }
     },
     "cordova-common": {
-      "version": "4.0.1-nightly.2020.5.1.82cded7d",
-      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.0.1-nightly.2020.5.1.82cded7d.tgz",
-      "integrity": "sha512-TNp9iJCDbKk2eZaS0maFQFAz3EzJIDc1VMEzZO5A1FL4RgZboODo5AdyPQmJg213tBC/cIP1VJR70BIvUFH98g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-4.0.1.tgz",
+      "integrity": "sha512-cfn5A9G99/T+wDz7pS0TCTqE6KMaPEQ+fZ+OfMJOMjxdvM891pfAEzQc9gr4ED1fjn59/0lMKjlKUbc6sjxeig==",
       "requires": {
         "@netflix/nerror": "^1.1.3",
         "ansi": "^0.3.1",
@@ -1876,9 +1876,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
-      "integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "requires": {
         "reusify": "^1.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:unit": "jasmine --config=tests/spec/unit.json"
   },
   "dependencies": {
-    "cordova-common": "^4.0.1-nightly.2020.5.1.82cded7d",
+    "cordova-common": "^4.0.1",
     "electron": "^8.2.5",
     "electron-builder": "^22.6.0",
     "execa": "^4.0.0",


### PR DESCRIPTION
### Motivation, Context & Description

Since the official `cordova-common@4.0.1` is released, we can now bump to the official release and stop using the nightly version.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
