### PR TITLE
fix(build): format top-level key for nsis-web

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -29,6 +29,10 @@ const PLATFORM_MAPPING = {
     win: 'win32'
 };
 
+const TARGET_TOP_LEVEL_KEY_MAPPING = {
+    'nsis-web': 'nsisWeb'
+};
+
 class ElectronBuilder {
     constructor (buildOptions, api) {
         this.api = api;
@@ -120,7 +124,9 @@ class ElectronBuilder {
 
                 if (typeof target === 'object' && Object.keys(target).length !== 0) {
                     const targetKey = Object.keys(target)[0];
-                    userBuildSettings.config[targetKey] = target[targetKey];
+                    const rootKey = TARGET_TOP_LEVEL_KEY_MAPPING[targetKey] || targetKey;
+
+                    userBuildSettings.config[rootKey] = target[targetKey];
                     target = targetKey;
                 }
 

--- a/tests/spec/unit/lib/build.spec.js
+++ b/tests/spec/unit/lib/build.spec.js
@@ -1261,6 +1261,33 @@ describe('Testing build.js:', () => {
             expect(buildOptions.buildConfig.electron.mac.signing.store.requirements).toBe(undefined);
         });
 
+        it('should format nsis-web taget with nsisWeb top-level configs in __formatAppendUserSettings.', () => {
+            // Sample target configuration option
+            const appPackageUrl = 'https://foo.bar/apps/win/web';
+            // The settings which will be populated by `__formatAppendUserSettings`
+            const userBuildSettings = {};
+            // platform config partial from `build.json`
+            const platformConfig = {
+                package: [
+                    { 'nsis-web': { appPackageUrl } }
+                ]
+            };
+            // the mock `build.json`
+            const buildConfig = { electron: { windows: platformConfig } };
+            // the build options which is passed from CLI/Lib to Platform Build
+            const buildOptions = { argv: [], buildConfig };
+
+            // // create spies
+            existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(false);
+            build.__set__('fs', { existsSync: existsSyncSpy });
+
+            electronBuilder = new ElectronBuilder(buildOptions, api)
+                .__formatAppendUserSettings('win', platformConfig, userBuildSettings);
+
+            expect(existsSyncSpy).toHaveBeenCalled();
+            expect(userBuildSettings.config.nsisWeb.appPackageUrl).toBe(appPackageUrl);
+        });
+
         it('should append user singing for windows', () => {
             // mock platformConfig, buildConfig and buildOptions Objects
             const platformConfig = {


### PR DESCRIPTION
### Motivation, Context & Description

Some build targets has configurations and are stored in a top-level key.

For example: if the target `dmg` is set, there is a `top-level` node in the configuration structure called `dmg` which contains its configurations.

Not all `top-level` keys match the `target` key. 

For example: `nsis-web` target key actually has a top-level key of `nsisWeb`

This PR adds a target key to top-level key mapping. If the target key exists in this mapping, it will use the defined top-level key else fall back to the target key.

### Testing

- `npm t`
- `cordova platform add`
- `cordova build electron`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
