### PR TITLE
feat: install devtool extensions for debug builds

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -36,11 +36,16 @@ Electron is a framework that uses web technologies (HTML, CSS, and JS) to build 
     - [How to Disable the Window From Being Resizable](#how-to-disable-the-window-from-being-resizable)
     - [How to Make the Window Fullscreen](#how-to-make-the-window-fullscreen)
     - [How to Support Node.js and Electron APIs](#how-to-support-nodejs-and-electron-apis)
+    - [Customizing BrowserWindow Instance Method](#customizing-browserwindow-instance-method)
+      - [Load a local HTML file using relative path from the `{project_dir}/www` directory](#load-a-local-html-file-using-relative-path-from-the-project_dirwww-directory)
+      - [Load a local HTML using full path](#load-a-local-html-using-full-path)
+      - [Load a remote URL](#load-a-remote-url)
   - [Customizing the Electron's Main Process](#customizing-the-electrons-main-process)
   - [Bundling Node Modules](#bundling-node-modules)
     - [Cordova Package Handling](#cordova-package-handling)
   - [DevTools](#devtools)
   - [Debugging the Application's Main Process](#debugging-the-applications-main-process)
+  - [Enable Developer Tool Exrtensions (Chrome Extensions)](#enable-developer-tool-exrtensions-chrome-extensions)
   - [Build Configurations](#build-configurations)
     - [Default Build Configurations](#default-build-configurations)
     - [Customizing Build Configurations](#customizing-build-configurations)
@@ -364,6 +369,49 @@ For example:
 
 ```shell
 cordova run electron --nobuild --debug -- --inspect-brk=5858
+```
+
+## Enable Developer Tool Exrtensions (Chrome Extensions)
+
+To enable a devtool extension, for a debug build, add the `devToolsExtension` collection to the Cordova Electron Settings file (`ElectronSettingsFilePath`).
+
+For example:
+
+```json
+{
+  "devToolsExtension": [
+    "VUEJS_DEVTOOLS"
+  ]
+}
+```
+
+Below is a list of pre-provided devtools that can be added.
+
+- `EMBER_INSPECTOR`
+- `REACT_DEVELOPER_TOOLS`
+- `BACKBONE_DEBUGGER`
+- `JQUERY_DEBUGGER`
+- `ANGULARJS_BATARANG`
+- `VUEJS_DEVTOOLS`
+- `REDUX_DEVTOOLS`
+- `REACT_PERF`
+- `CYCLEJS_DEVTOOL`
+- `APOLLO_DEVELOPER_TOOLS`
+- `MOBX_DEVTOOLS`
+
+If there are any devtools or extensions you wish to use that are avaiable in the Chrome App Store, you can add them by provided the extension's app ID.
+
+**Note:** The developer tools & extensions are not installed on a release build.
+
+**Example:**
+
+```json
+{
+    "browserWindow": {
+        "width": 1024,
+        "height": 768
+    }
+}
 ```
 
 ## Build Configurations

--- a/bin/templates/platform_www/cdv-electron-main.js
+++ b/bin/templates/platform_www/cdv-electron-main.js
@@ -29,6 +29,10 @@ const {
 const cdvElectronSettings = require('./cdv-electron-settings.json');
 const reservedScheme = require('./cdv-reserved-scheme.json');
 
+const devTools = cdvElectronSettings.browserWindow.webPreferences.devTools
+    ? require('electron-devtools-installer')
+    : false;
+
 const scheme = cdvElectronSettings.scheme;
 const hostname = cdvElectronSettings.hostname;
 const isFileProtocol = scheme === 'file';
@@ -104,6 +108,13 @@ function configureProtocol () {
 app.on('ready', () => {
     if (!isFileProtocol) {
         configureProtocol();
+    }
+
+    if (devTools && cdvElectronSettings.devToolsExtension) {
+        const extensions = cdvElectronSettings.devToolsExtension.map(id => devTools[id] || id);
+        devTools.default(extensions) // default = install extension
+            .then((name) => console.log(`Added Extension:  ${name}`))
+            .catch((err) => console.log('An error occurred: ', err));
     }
 
     createWindow();

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -32,6 +32,7 @@ const {
     PlatformJson,
     PluginInfoProvider
 } = require('cordova-common');
+const { getPackageJson } = require('./util');
 const Parser = require('./parser');
 
 function setupEvents (externalEventEmitter) {
@@ -349,17 +350,8 @@ class Api {
     }
 
     static version () {
-        let platformPkg = null;
-
-        try {
-            // coming from user project
-            platformPkg = require(require.resolve('cordova-electron/package.json'));
-        } catch (e) {
-            // coming from repo test & coho
-            platformPkg = require('../package.json');
-        }
-
-        return platformPkg.version;
+        const packageJson = getPackageJson();
+        return packageJson.version;
     }
 }
 // @todo create projectInstance and fulfill promise with it.

--- a/lib/PackageJsonParser.js
+++ b/lib/PackageJsonParser.js
@@ -95,6 +95,15 @@ Packages defined as a dependency will be bundled with the application and can in
         return this;
     }
 
+    enableDevTools (enable = false) {
+        if (enable) {
+            if (!this.package.dependencies) this.package.dependencies = {};
+            this.package.dependencies['electron-devtools-installer'] = '^3.1.0';
+        }
+
+        return this;
+    }
+
     configureHomepage (config) {
         this.package.homepage = (config.doc.find('author') && config.doc.find('author').attrib.href) || 'https://cordova.io';
     }

--- a/lib/PackageJsonParser.js
+++ b/lib/PackageJsonParser.js
@@ -20,6 +20,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const { events } = require('cordova-common');
+const { getPackageJson } = require('./util');
 
 class PackageJsonParser {
     constructor (wwwDir, projectRootDir) {
@@ -97,8 +98,14 @@ Packages defined as a dependency will be bundled with the application and can in
 
     enableDevTools (enable = false) {
         if (enable) {
-            if (!this.package.dependencies) this.package.dependencies = {};
-            this.package.dependencies['electron-devtools-installer'] = '^3.1.0';
+            const pkgJson = getPackageJson();
+            const devToolsDependency = 'electron-devtools-installer';
+
+            if (!this.package.dependencies) {
+                this.package.dependencies = {};
+            }
+
+            this.package.dependencies[devToolsDependency] = pkgJson.dependencies[devToolsDependency];
         }
 
         return this;

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -76,6 +76,7 @@ module.exports.prepare = function (cordovaProject, options) {
 
     (new PackageJsonParser(this.locations.www, cordovaProject.root))
         .configure(this.config, projectPackageJson)
+        .enableDevTools(options && options.options && !options.options.release)
         .write();
 
     const userElectronSettings = cordovaProject.projectConfig.getPlatformPreference('ElectronSettingsFilePath', 'electron');

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,6 +17,8 @@
     under the License.
 */
 
+let _packageJson = null;
+
 module.exports.deepMerge = (mergeTo, mergeWith) => {
     for (const property in mergeWith) {
         if (Object.prototype.toString.call(mergeWith[property]) === '[object Object]') {
@@ -29,4 +31,24 @@ module.exports.deepMerge = (mergeTo, mergeWith) => {
     }
 
     return mergeTo;
+};
+
+/**
+ * Gets the `cordova-electron` package.json file.
+ * The path to the file depends on if called from a unit testing or an actual Cordova project.
+ *
+ * @return {Object} package.json content
+ */
+module.exports.getPackageJson = () => {
+    if (_packageJson) return _packageJson;
+
+    try {
+        // coming from user project
+        _packageJson = require(require.resolve('cordova-electron/package.json'));
+    } catch (e) {
+        // coming from repo test & coho
+        _packageJson = require('../package.json');
+    }
+
+    return _packageJson;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1280,13 +1280,13 @@
       }
     },
     "electron-devtools-installer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-3.1.0.tgz",
-      "integrity": "sha512-qZd1Aoya8YOK6QauNX92V5qyKGtb4lbs238bP+qtMBkXts24xJ/1PtOVBPvdg5w3Ts9L5o6I9sDErKuzHeJFDA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-3.1.1.tgz",
+      "integrity": "sha512-g2D4J6APbpsiIcnLkFMyKZ6bOpEJ0Ltcc2m66F7oKUymyGAt628OWeU9nRZoh1cNmUs/a6Cls2UfOmsZtE496Q==",
       "requires": {
         "rimraf": "^3.0.2",
         "semver": "^7.2.1",
-        "unzip-crx": "^0.2.0"
+        "unzip-crx-3": "^0.2.0"
       },
       "dependencies": {
         "rimraf": {
@@ -4184,10 +4184,10 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
-    "unzip-crx": {
+    "unzip-crx-3": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/unzip-crx/-/unzip-crx-0.2.0.tgz",
-      "integrity": "sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=",
+      "resolved": "https://registry.npmjs.org/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz",
+      "integrity": "sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==",
       "requires": {
         "jszip": "^3.1.0",
         "mkdirp": "^0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,6 +1279,26 @@
         "yargs": "^15.3.1"
       }
     },
+    "electron-devtools-installer": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-3.1.0.tgz",
+      "integrity": "sha512-qZd1Aoya8YOK6QauNX92V5qyKGtb4lbs238bP+qtMBkXts24xJ/1PtOVBPvdg5w3Ts9L5o6I9sDErKuzHeJFDA==",
+      "requires": {
+        "rimraf": "^3.0.2",
+        "semver": "^7.2.1",
+        "unzip-crx": "^0.2.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "electron-publish": {
       "version": "22.7.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.7.0.tgz",
@@ -2271,6 +2291,11 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -2728,6 +2753,17 @@
         "universalify": "^1.0.0"
       }
     },
+    "jszip": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
+      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -2757,6 +2793,14 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "load-json-file": {
@@ -3178,6 +3222,11 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -3693,6 +3742,11 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4130,6 +4184,16 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
+    "unzip-crx": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/unzip-crx/-/unzip-crx-0.2.0.tgz",
+      "integrity": "sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=",
+      "requires": {
+        "jszip": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "yaku": "^0.16.6"
+      }
+    },
     "update-notifier": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
@@ -4314,6 +4378,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "yaku": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/yaku/-/yaku-0.16.7.tgz",
+      "integrity": "sha1-HRlceKqbW/hHnIlblQT9TwhHmE4="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cordova-common": "^4.0.1",
     "electron": "^9.0.0",
     "electron-builder": "^22.7.0",
+    "electron-devtools-installer": "^3.1.0",
     "execa": "^4.0.0",
     "fs-extra": "^9.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cordova-common": "^4.0.1",
     "electron": "^9.0.0",
     "electron-builder": "^22.7.0",
-    "electron-devtools-installer": "^3.1.0",
+    "electron-devtools-installer": "^3.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^9.0.0"
   },

--- a/tests/spec/unit/lib/Api.spec.js
+++ b/tests/spec/unit/lib/Api.spec.js
@@ -475,31 +475,9 @@ describe('Api prototype methods', () => {
 
     describe('version method', () => {
         it('should get version from cordova-electron package.', () => {
-            const dummyRequire = path => {
-                expect(path).toEqual('cordova-elecrtron-resolved-package-path');
+            Api.__set__('getPackageJson', () => {
                 return { version: '1.0.0' };
-            };
-
-            dummyRequire.resolve = path => {
-                return 'cordova-elecrtron-resolved-package-path';
-            };
-
-            Api.__set__('require', dummyRequire);
-
-            expect(Api.version()).toEqual('1.0.0');
-        });
-
-        it('should get version from package.json.', () => {
-            const dummyRequire = path => {
-                expect(path).toEqual('../package.json');
-                return { version: '1.0.0' };
-            };
-
-            dummyRequire.resolve = path => {
-                throw Error('random error');
-            };
-
-            Api.__set__('require', dummyRequire);
+            });
 
             expect(Api.version()).toEqual('1.0.0');
         });

--- a/tests/spec/unit/lib/PackageJsonParser.spec.js
+++ b/tests/spec/unit/lib/PackageJsonParser.spec.js
@@ -79,6 +79,39 @@ describe('PackageJsonParser class', () => {
         expect(packageJsonParser.package).toEqual(defaultInitPackageObj);
     });
 
+    it('should not modify the package object when config is not provided.', () => {
+        packageJsonParser.configure();
+        // the package object should be the same as it was initialized
+        expect(packageJsonParser.package).toEqual(defaultInitPackageObj);
+    });
+
+    it('should not add dev tools extension when enable argument = false.', () => {
+        packageJsonParser.enableDevTools(false);
+        // the package object should be the same as it was initialized
+        expect(packageJsonParser.package.dependencies).not.toBeDefined();
+    });
+
+    it('should not add dev tools extension when enable argument = undefined.', () => {
+        packageJsonParser.enableDevTools();
+        // the package object should be the same as it was initialized
+        expect(packageJsonParser.package.dependencies).not.toBeDefined();
+    });
+
+    it('should add dev tools extension when enable argument = true.', () => {
+        packageJsonParser.enableDevTools(true);
+        // the package object should be the same as it was initialized
+        expect(packageJsonParser.package.dependencies).toBeDefined();
+        expect(packageJsonParser.package.dependencies['electron-devtools-installer']).toBeDefined();
+    });
+
+    it('should not create dependencies object if it exists an enable argument = true.', () => {
+        packageJsonParser.package.dependencies = {}; // mocking that the object already exists
+        packageJsonParser.enableDevTools(true);
+        // the package object should be the same as it was initialized
+        expect(packageJsonParser.package.dependencies).toBeDefined();
+        expect(packageJsonParser.package.dependencies['electron-devtools-installer']).toBeDefined();
+    });
+
     it('should update the package object with default values, when config.xml is empty.', () => {
         packageJsonParser.configure(cfgEmpty, defaultMockProjectPackageJson);
 


### PR DESCRIPTION
### Motivation, Context & Description

- Added support to install & enable developer tool extension
- Centralize the fetching of platform's `package.json` in `util.js`
- Updated `Api.version` to use centralized fetch method
- Updated `Api.version` unit-test
- New feature uses centralized fetch method
- Added unit test for new feature

**Details on New Feature**

- New feature uses the dependency `electron-devtools-installer` to install the devtool extensions that are on Chrome App Store during project build.
- This dependency is added to the Electron project only for debug builds.
- Cordova's implementation does not support adding this dependency in any way to a release build.
- The dependency pre-provided extension keys to quickly install without knowing an ID [`electron-devtools-installer` Extension Keys](https://github.com/MarshallOfSound/electron-devtools-installer/tree/v3.1.1#what-extensions-can-i-use).
  - `EMBER_INSPECTOR`
  - `REACT_DEVELOPER_TOOLS`
  - `BACKBONE_DEBUGGER`
  - `JQUERY_DEBUGGER`
  - `ANGULARJS_BATARANG`
  - `VUEJS_DEVTOOLS`
  - `REDUX_DEVTOOLS`
  - `REACT_PERF`
  - `CYCLEJS_DEVTOOL`
  - `APOLLO_DEVELOPER_TOOLS`
  - `MOBX_DEVTOOLS`
- The extensions which are installed are fetched from the Chrome App Store.
- If the extensions listed above does not contain an extension you need, you can lookup use a Chrome Store App ID to install the extension. (Again only for debug builds.)

### Testing

- `npm t`
- `cordova build electron`
- `cordova run electron --nobuild`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] I've updated the documentation if necessary
