### PR TITLE
breaking: use platform's common config parser

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -28,6 +28,7 @@ const {
     ConfigChanges: { PlatformMunger },
     CordovaError,
     CordovaLogger,
+    ConfigParser,
     events: selfEvents,
     PlatformJson,
     PluginInfoProvider
@@ -93,6 +94,9 @@ class Api {
     }
 
     prepare (cordovaProject, options) {
+        // Use Cordova Electron's Common Dependency
+        cordovaProject.projectConfig = new ConfigParser(cordovaProject.projectConfig.path);
+
         return require('./prepare').prepare.call(this, cordovaProject, options);
     }
 

--- a/tests/spec/unit/lib/Api.spec.js
+++ b/tests/spec/unit/lib/Api.spec.js
@@ -65,7 +65,7 @@ describe('Api class', () => {
 
     beforeAll(() => {
         fs.ensureDirSync(tmpDir);
-        fs.copySync(path.resolve(fixturesDir, 'testapp'), path.resolve(tmpDir, 'testapp'));
+        fs.copySync(path.resolve(fixturesDir, 'testapp'), testProjectDir);
 
         apiEvents = Api.__get__('selfEvents');
         apiEvents.addListener('verbose', (data) => { });
@@ -131,8 +131,21 @@ describe('Api class', () => {
             const prepare = jasmine.createSpy('prepare');
 
             Api.__set__('require', () => ({ prepare }));
-            api.prepare('', {});
-            expect(prepare).toHaveBeenCalledWith(jasmine.any(String), jasmine.any(Object));
+
+            // Mock project configs coming from lib.
+            const appendProjectPath = (dirFile) => path.join(api.root, dirFile);
+            const project = {
+                root: api.root,
+                projectConfig: new ConfigParser(appendProjectPath('config.xml')),
+                locations: {
+                    plugins: appendProjectPath('plugins'),
+                    www: appendProjectPath('www'),
+                    rootConfigXml: appendProjectPath('config.xml')
+                }
+            };
+
+            api.prepare(project, {});
+            expect(prepare).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Object));
             Api.__set__('require', apiRequire);
         });
     });


### PR DESCRIPTION
### Motivation,  Context & Description

There are possibilities that the Cordova-Lib's version of Cordova-Common does not matching the platform's version. There can be cases where the platform introduces supporting logic in common and pins itself to use the new version.

A good example where this case happened in the past was with Adaptive Icons in Cordova Android. Supportive logic was added to common and the platform was pinned but anyone who used the latest platform had issues with adaptive icon because the Lib version of common which was passed to platform and used during prepare was old.

It is expected that platform's common can be updated to a version that lib does not use.

This PR will recreate the common object during prepare with the platform's installed common.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I updated automated test coverage as appropriate for this change
