### PR TITLE
fix(Api): do not depend on globals

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -17,12 +17,6 @@
     under the License.
 */
 
-const { resolve } = require('path');
-
-// Setting up some global defaults to share accross all files
-global.cdvPlatformPath = resolve(__dirname, '..');
-global.cdvProjectPath = resolve(__dirname, '../../..');
-
 try {
     module.exports = require('cordova-electron');
 } catch (error) {

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -342,7 +342,7 @@ class Api {
     }
 
     run (runOptions) {
-        return require('./run').run(runOptions);
+        return require('./run').run.call(this, runOptions);
     }
 
     clean (cleanOptions) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -21,12 +21,12 @@ const electron = require('electron');
 const execa = require('execa');
 const path = require('path');
 
-module.exports.run = (args = {}) => {
+module.exports.run = function (args = {}) {
     const electonArgs = args.argv || [];
 
     // Add the path to the main process as the last Electron argument to pass into execa
     electonArgs.push(
-        path.join(global.cdvPlatformPath, 'www/cdv-electron-main.js')
+        path.join(this.locations.www, 'cdv-electron-main.js')
     );
 
     const child = execa(electron, electonArgs);

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -22,6 +22,12 @@ const path = require('path');
 
 const rootDir = path.resolve(__dirname, '../../../..');
 
+const apiStub = Object.freeze({
+    locations: Object.freeze({ www: 'FAKE_WWW' })
+});
+
+const expectedPathToMain = path.join(apiStub.locations.www, 'cdv-electron-main.js');
+
 const run = rewire(path.join(rootDir, 'lib/run'));
 
 describe('Run', () => {
@@ -29,7 +35,6 @@ describe('Run', () => {
         it('should run electron with cdv-electron-main.js.', () => {
             const execaSpy = jasmine.createSpy('execa');
             const onSpy = jasmine.createSpy('on');
-            const expectedPathToMain = path.join(rootDir, 'bin/templates/www/cdv-electron-main.js');
 
             run.__set__('electron', 'electron-require');
             spyOn(process, 'exit');
@@ -38,7 +43,7 @@ describe('Run', () => {
                 on: onSpy.and.callThrough()
             }));
 
-            run.run();
+            run.run.call(apiStub);
 
             expect(execaSpy).toHaveBeenCalledWith('electron-require', [expectedPathToMain]);
             expect(onSpy).toHaveBeenCalled();
@@ -54,7 +59,7 @@ describe('Run', () => {
             const onSpy = jasmine.createSpy('on');
             const expectedElectronArguments = [
                 '--inspect-brk=5858',
-                path.join(rootDir, 'bin/templates/www/cdv-electron-main.js')
+                expectedPathToMain
             ];
 
             run.__set__('electron', 'electron-require');
@@ -64,7 +69,7 @@ describe('Run', () => {
                 on: onSpy.and.callThrough()
             }));
 
-            run.run({ argv: ['--inspect-brk=5858'] });
+            run.run.call(apiStub, { argv: ['--inspect-brk=5858'] });
 
             expect(execaSpy).toHaveBeenCalledWith('electron-require', expectedElectronArguments);
             expect(onSpy).toHaveBeenCalled();


### PR DESCRIPTION
### Motivation and Context
The use of globals in the bridge Api broke a few use-cases:
    - loading the bridge Api from two different locations
    - requiring `cordova-electron` without setting the globals first


### Description
This change refactors the run module back to an "extension method" of `Api`. That is, it has to be called with `this` set to an `Api` instance. This pattern is also used for `build` and `run` and it is pretty common among the other platforms as well.


### Testing
- I have updated the `run` unit test
- All automated tests pass
