### PR TITLE
fix(pkg): typo in field "keywords"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Api.js",
   "repository": "github:apache/cordova-electron",
   "bugs": "https://github.com/apache/cordova-electron/issues",
-  "kewords": [
+  "keywords": [
     "apache",
     "cordova",
     "cordova:platform",


### PR DESCRIPTION
Related to https://github.com/apache/cordova/issues/55
