### PR TITLE
fix(windows): electron window not displaying

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -29,7 +29,7 @@ module.exports.run = function (args = {}) {
         path.join(this.locations.www, 'cdv-electron-main.js')
     );
 
-    const child = execa(electron, electonArgs);
+    const child = execa(electron, electonArgs, { windowsHide: false });
 
     child.on('close', (code) => {
         process.exit(code);

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -27,6 +27,7 @@ const apiStub = Object.freeze({
 });
 
 const expectedPathToMain = path.join(apiStub.locations.www, 'cdv-electron-main.js');
+const expectedExecaOptions = { windowsHide: false };
 
 const run = rewire(path.join(rootDir, 'lib/run'));
 
@@ -45,7 +46,7 @@ describe('Run', () => {
 
             run.run.call(apiStub);
 
-            expect(execaSpy).toHaveBeenCalledWith('electron-require', [expectedPathToMain]);
+            expect(execaSpy).toHaveBeenCalledWith('electron-require', [expectedPathToMain], expectedExecaOptions);
             expect(onSpy).toHaveBeenCalled();
             expect(process.exit).not.toHaveBeenCalled();
 
@@ -71,7 +72,7 @@ describe('Run', () => {
 
             run.run.call(apiStub, { argv: ['--inspect-brk=5858'] });
 
-            expect(execaSpy).toHaveBeenCalledWith('electron-require', expectedElectronArguments);
+            expect(execaSpy).toHaveBeenCalledWith('electron-require', expectedElectronArguments, expectedExecaOptions);
             expect(onSpy).toHaveBeenCalled();
             expect(process.exit).not.toHaveBeenCalled();
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- Windows (electron window is hidden)
- others (stdio is ignored)

### Motivation and Context
On windows platform using nodejs 11+, the electron window does not appear.

### Description
 `windowsHide: false` makes the electron window appear on windows.

### Testing
I manually tested my changes on windows.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
