### PR TITLE
fix: restrict deep merging on reserved keys

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -21,6 +21,10 @@ let _packageJson = null;
 
 module.exports.deepMerge = (mergeTo, mergeWith) => {
     for (const property in mergeWith) {
+        if ((property === '__proto__' || property === 'constructor' || property === 'prototype')) {
+            continue;
+        }
+
         if (Object.prototype.toString.call(mergeWith[property]) === '[object Object]') {
             mergeTo[property] = module.exports.deepMerge((mergeTo[property] || {}), mergeWith[property]);
         } else if (Object.prototype.toString.call(mergeWith[property]) === '[object Array]') {

--- a/tests/spec/unit/lib/util.spec.js
+++ b/tests/spec/unit/lib/util.spec.js
@@ -38,5 +38,21 @@ describe('Testing util.js:', () => {
 
             expect(actual).toEqual(expected);
         });
+
+        it('should reject deep merge on reserved keys.', () => {
+            const mergeTo = { foo: 'bar', abc: [1, 2, 3] };
+            const payload = '{"food":"candy","abc":[5],"__proto__":{ "hoge":"hoge"}}';
+
+            const actual = util.deepMerge(mergeTo, JSON.parse(payload));
+            const expected = {
+                foo: 'bar',
+                food: 'candy',
+                abc: [1, 2, 3, 5]
+            };
+
+            expect(actual).toEqual(expected);
+            expect(actual.hoge).toBe(undefined);
+            expect({}.hoge).toBe(undefined);
+        });
     });
 });


### PR DESCRIPTION
### Motivation, Context & Description

* Reject deep merge on reserved keys

### Testing

* `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change