### PR TITLE
feat: forward electron’s process stdio to terminal

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -29,7 +29,7 @@ module.exports.run = function (args = {}) {
         path.join(this.locations.www, 'cdv-electron-main.js')
     );
 
-    const child = execa(electron, electonArgs, { windowsHide: false });
+    const child = execa(electron, electonArgs, { windowsHide: false, stdio: 'inherit' });
 
     child.on('close', (code) => {
         process.exit(code);

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -27,7 +27,7 @@ const apiStub = Object.freeze({
 });
 
 const expectedPathToMain = path.join(apiStub.locations.www, 'cdv-electron-main.js');
-const expectedExecaOptions = { windowsHide: false };
+const expectedExecaOptions = { windowsHide: false, stdio: 'inherit' };
 
 const run = rewire(path.join(rootDir, 'lib/run'));
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Running `cordova run electron` does not display the output of electron (console.log from cdv-electron-main.js is ignored)


### Description
<!-- Describe your changes in detail -->
My changes cause the electron process to inherit stdio.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I tested the changes on windows.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
