### PR TITLE
feat!: update node support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
### Motivation and Context

Drop support for node 10.x and lower. Node 10.x has reached the EoL (2021-04-30). 

It is recommended that users upgrade node to at least 12.x or higher. Node 12.x is currently in maintenance mode and will reach its EoL sometime around 2022-04-30.

### Description

- Dropped node 10.x from GH Actions strategy.
- Added node 16.x to GH Actions strategy.
- Bump node engine requirement to `>=10.0.0`.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
