### PR TITLE
feat!(Api): remove unused locations data

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -73,10 +73,7 @@ class Api {
             defaultConfigXml: path.join(this.root, 'cordova/defaults.xml'),
             build: path.join(this.root, 'build'),
             buildRes: path.join(this.root, 'build-res'),
-            cache: path.join(this.root, 'cache'),
-            // NOTE: Due to platformApi spec we need to return relative paths here
-            cordovaJs: 'bin/templates/project/assets/www/cordova.js',
-            cordovaJsSrc: 'cordova-js-src'
+            cache: path.join(this.root, 'cache')
         };
 
         this._platformJson = PlatformJson.load(this.root, this.platform);

--- a/tests/spec/unit/lib/Api.spec.js
+++ b/tests/spec/unit/lib/Api.spec.js
@@ -54,9 +54,7 @@ const mockExpectedLocations = {
     defaultConfigXml: path.join(testProjectDir, 'cordova/defaults.xml'),
     build: path.join(testProjectDir, 'build'),
     buildRes: path.join(testProjectDir, 'build-res'),
-    cache: path.join(testProjectDir, 'cache'),
-    cordovaJs: 'bin/templates/project/assets/www/cordova.js',
-    cordovaJsSrc: 'cordova-js-src'
+    cache: path.join(testProjectDir, 'cache')
 };
 
 describe('Api class', () => {


### PR DESCRIPTION
### Motivation and Context

While cleaning up, saw these unused location paths. Removing them but flaging as a breaking change.

### Description

* `Api.js`
  * The `cordovaJs` location was removed as it was not used anywhere in code except for tests.
    * Appears to be leftover code from other platforms but also not used in those platforms as well
    * path is also old and not correct anymore. It changed in an earlier PR which restructured the platform.
  * The `cordovaJsSrc` location was removed as it was not used anywhere in code except for tests.
    * Appears to be leftover code from other platforms but also not used in those platforms as well

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
