### PR TITLE
doc: mas-dev is macOS package

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -502,7 +502,7 @@ The configuration example below will generate `tar.gz`, `dmg` and `zip` packages
 | default      |    -    | `dmg`<br />`zip` |             -              |
 | dmg          |    -    |     &#9989;      |             -              |
 | mas          |    -    |     &#9989;      |             -              |
-| mas-dev      | &#9989; |        -         |             -              |
+| mas-dev      |         |     &#9989;      |             -              |
 | pkg          |    -    |     &#9989;      |             -              |
 | 7z           | &#9989; |     &#9989;      |          &#9989;           |
 | zip          | &#9989; |     &#9989;      |          &#9989;           |


### PR DESCRIPTION
### Motivation and Context

`mas-dev` target type is a macOS target, not Linux

* [Linux Available Targets](https://www.electron.build/configuration/linux)
* [macOS Available Targets](https://www.electron.build/configuration/mac)

### Description

Updated the docs to correct this mistake.

### Checklist

- [x] I've updated the documentation if necessary
