### PR TITLE
Fix paralell npm install in case of multiple frameworks

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -117,7 +117,7 @@ module.exports = {
 
             const wwwDir = path.join(project_dir, 'www');
 
-            execa('npm', ['install', electronPluginSrc], {
+            execa.sync('npm', ['install', electronPluginSrc], {
                 cwd: wwwDir
             });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
Fixes #211



### Description
Changed execa to run synchronously.




### Testing
Manually tested with 3 frameworks each having clashing dependencies in one plugin added into project.

*Before change:*

1. (re)add the plugin several times (10+)
2. run the app (--nobuild)
3. app fails to start due to some random resolve issue in unrelated dependencies

*After change:*

1. (re)add the plugin several times (10+)
2. run the app (--nobuild)
3. no issue in regards to failed imports observed






### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
