### PR TITLE
fix: ENOENT. spawn /usr/bin/python

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cordova-common": "^4.0.2",
         "electron": "^18.2.4",
-        "electron-builder": "^22.14.13",
+        "electron-builder": "^23.0.3",
         "electron-devtools-installer": "^3.2.0",
         "execa": "^5.1.1",
         "fs-extra": "^10.1.0"
@@ -528,15 +528,17 @@
       }
     },
     "node_modules/@electron/universal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
-      "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.0.tgz",
+      "integrity": "sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==",
       "dependencies": {
         "@malept/cross-spawn-promise": "^1.1.0",
-        "asar": "^3.0.3",
+        "asar": "^3.1.0",
         "debug": "^4.3.1",
         "dir-compare": "^2.4.0",
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^9.0.1",
+        "minimatch": "^3.0.4",
+        "plist": "^3.0.4"
       },
       "engines": {
         "node": ">=8.6"
@@ -1116,28 +1118,28 @@
       }
     },
     "node_modules/app-builder-bin": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
-      "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA=="
     },
     "node_modules/app-builder-lib": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.13.tgz",
-      "integrity": "sha512-SufmrtxU+D0Tn948fjEwAOlCN9757UXLkzzTWXMwZKR/5hisvgqeeBepWfphMIE6OkDGz0fbzEhL1P2Pty4XMg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.3.tgz",
+      "integrity": "sha512-1qrtXYHXJfXhzJnMtVGjIva3067F1qYQubl2oBjI61gCBoCHvhghdYJ57XxXTQQ0VxnUhg1/Iaez87uXp8mD8w==",
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.0.5",
+        "@electron/universal": "1.2.0",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
-        "electron-osx-sign": "^0.5.0",
-        "electron-publish": "22.14.13",
+        "electron-osx-sign": "^0.6.0",
+        "electron-publish": "23.0.2",
         "form-data": "^4.0.0",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
@@ -1509,16 +1511,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builder-util": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.13.tgz",
-      "integrity": "sha512-oePC/qrrUuerhmH5iaCJzPRAKlSBylrhzuAJmRQClTyWnZUv6jbaHh+VoHMbEiE661wrj2S2aV7/bQh12cj1OA==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.2.tgz",
+      "integrity": "sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
         "7zip-bin": "~5.1.1",
-        "app-builder-bin": "3.7.1",
+        "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.9.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
@@ -1533,9 +1535,9 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "8.9.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.2.tgz",
-      "integrity": "sha512-rhuKm5vh7E0aAmT6i8aoSfEjxzdYEFX7zDApK+eNgOhjofnWb74d9SRJv0H/8nsgOkos0TZ4zxW0P8J4N7xQ2A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
+      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
       "dependencies": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -2091,13 +2093,13 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.13.tgz",
-      "integrity": "sha512-xNOugB6AbIRETeU2uID15sUfjdZZcKdxK8xkFnwIggsM00PJ12JxpLNPTjcRoUnfwj3WrPjilrO64vRMwNItQg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.3.tgz",
+      "integrity": "sha512-mBYrHHnSM5PC656TDE+xTGmXIuWHAGmmRfyM+dV0kP+AxtwPof4pAXNQ8COd0/exZQ4dqf72FiPS3B9G9aB5IA==",
       "dependencies": {
-        "app-builder-lib": "22.14.13",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -2205,16 +2207,16 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.13.tgz",
-      "integrity": "sha512-3fgLxqF2TXVKiUPeg74O4V3l0l3j7ERLazo8sUbRkApw0+4iVAf2BJkHsHMaXiigsgCoEzK/F4/rB5rne/VAnw==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.3.tgz",
+      "integrity": "sha512-0lnTsljAgcOMuIiOjPcoFf+WxOOe/O04hZPgIvvUBXIbz3kolbNu0Xdch1f5WuQ40NdeZI7oqs8Eo395PcuGHQ==",
       "dependencies": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "22.14.13",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
-        "dmg-builder": "22.14.13",
+        "dmg-builder": "23.0.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -2256,9 +2258,9 @@
       }
     },
     "node_modules/electron-osx-sign": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
-      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
+      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
       "dependencies": {
         "bluebird": "^3.5.0",
         "compare-version": "^0.1.2",
@@ -2300,13 +2302,13 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/electron-publish": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.13.tgz",
-      "integrity": "sha512-0oP3QiNj3e8ewOaEpEJV/o6Zrmy2VarVvZ/bH7kyO/S/aJf9x8vQsKVWpsdmSiZ5DJEHgarFIXrnO0ZQf0P9iQ==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.2.tgz",
+      "integrity": "sha512-8gMYgWqv96lc83FCm85wd+tEyxNTJQK7WKyPkNkO8GxModZqt1GO8S+/vAnFGxilS/7vsrVRXFfqiCDUCSuxEg==",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -6813,15 +6815,17 @@
       }
     },
     "@electron/universal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
-      "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.0.tgz",
+      "integrity": "sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==",
       "requires": {
         "@malept/cross-spawn-promise": "^1.1.0",
-        "asar": "^3.0.3",
+        "asar": "^3.1.0",
         "debug": "^4.3.1",
         "dir-compare": "^2.4.0",
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^9.0.1",
+        "minimatch": "^3.0.4",
+        "plist": "^3.0.4"
       },
       "dependencies": {
         "fs-extra": {
@@ -7283,28 +7287,28 @@
       }
     },
     "app-builder-bin": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
-      "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA=="
     },
     "app-builder-lib": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.13.tgz",
-      "integrity": "sha512-SufmrtxU+D0Tn948fjEwAOlCN9757UXLkzzTWXMwZKR/5hisvgqeeBepWfphMIE6OkDGz0fbzEhL1P2Pty4XMg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.3.tgz",
+      "integrity": "sha512-1qrtXYHXJfXhzJnMtVGjIva3067F1qYQubl2oBjI61gCBoCHvhghdYJ57XxXTQQ0VxnUhg1/Iaez87uXp8mD8w==",
       "requires": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.0.5",
+        "@electron/universal": "1.2.0",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
-        "electron-osx-sign": "^0.5.0",
-        "electron-publish": "22.14.13",
+        "electron-osx-sign": "^0.6.0",
+        "electron-publish": "23.0.2",
         "form-data": "^4.0.0",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
@@ -7562,16 +7566,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "builder-util": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.13.tgz",
-      "integrity": "sha512-oePC/qrrUuerhmH5iaCJzPRAKlSBylrhzuAJmRQClTyWnZUv6jbaHh+VoHMbEiE661wrj2S2aV7/bQh12cj1OA==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.2.tgz",
+      "integrity": "sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==",
       "requires": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
         "7zip-bin": "~5.1.1",
-        "app-builder-bin": "3.7.1",
+        "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.9.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
@@ -7586,9 +7590,9 @@
       }
     },
     "builder-util-runtime": {
-      "version": "8.9.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.2.tgz",
-      "integrity": "sha512-rhuKm5vh7E0aAmT6i8aoSfEjxzdYEFX7zDApK+eNgOhjofnWb74d9SRJv0H/8nsgOkos0TZ4zxW0P8J4N7xQ2A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
+      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
       "requires": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -8011,13 +8015,13 @@
       }
     },
     "dmg-builder": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.13.tgz",
-      "integrity": "sha512-xNOugB6AbIRETeU2uID15sUfjdZZcKdxK8xkFnwIggsM00PJ12JxpLNPTjcRoUnfwj3WrPjilrO64vRMwNItQg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.3.tgz",
+      "integrity": "sha512-mBYrHHnSM5PC656TDE+xTGmXIuWHAGmmRfyM+dV0kP+AxtwPof4pAXNQ8COd0/exZQ4dqf72FiPS3B9G9aB5IA==",
       "requires": {
-        "app-builder-lib": "22.14.13",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "dmg-license": "^1.0.9",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
@@ -8091,16 +8095,16 @@
       }
     },
     "electron-builder": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.13.tgz",
-      "integrity": "sha512-3fgLxqF2TXVKiUPeg74O4V3l0l3j7ERLazo8sUbRkApw0+4iVAf2BJkHsHMaXiigsgCoEzK/F4/rB5rne/VAnw==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.3.tgz",
+      "integrity": "sha512-0lnTsljAgcOMuIiOjPcoFf+WxOOe/O04hZPgIvvUBXIbz3kolbNu0Xdch1f5WuQ40NdeZI7oqs8Eo395PcuGHQ==",
       "requires": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "22.14.13",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
-        "dmg-builder": "22.14.13",
+        "dmg-builder": "23.0.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -8131,9 +8135,9 @@
       }
     },
     "electron-osx-sign": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
-      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
+      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
       "requires": {
         "bluebird": "^3.5.0",
         "compare-version": "^0.1.2",
@@ -8167,13 +8171,13 @@
       }
     },
     "electron-publish": {
-      "version": "22.14.13",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.13.tgz",
-      "integrity": "sha512-0oP3QiNj3e8ewOaEpEJV/o6Zrmy2VarVvZ/bH7kyO/S/aJf9x8vQsKVWpsdmSiZ5DJEHgarFIXrnO0ZQf0P9iQ==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.2.tgz",
+      "integrity": "sha512-8gMYgWqv96lc83FCm85wd+tEyxNTJQK7WKyPkNkO8GxModZqt1GO8S+/vAnFGxilS/7vsrVRXFfqiCDUCSuxEg==",
       "requires": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "22.14.13",
-        "builder-util-runtime": "8.9.2",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "cordova-common": "^4.0.2",
     "electron": "^18.2.4",
-    "electron-builder": "^22.14.13",
+    "electron-builder": "^23.0.3",
     "electron-devtools-installer": "^3.2.0",
     "execa": "^5.1.1",
     "fs-extra": "^10.1.0"


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes the "ENOENT. spawn /usr/bin/python" error during build.

Resolves #220

### Description

This error is coming from the `electron-builder` dependency. The issue was resolved in the latest major release `23.x`.

For more information, see: https://github.com/electron-userland/electron-builder/issues/6726

In this PR:

- Bumped npm package dependency `electron-builder@^23.0.3`

### Current Workaround Solution without PR

Use the npm 8 `overrides` property:

```json
"overrides": {
  "cordova-electron": {
    "electron-builder": "^23.0.3"
  }
}
```

The environment will require `node >=14.14` and `npm >= 8` with this workaround.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
