### PR TITLE
fix: npm 8 does not install plugin dependencies

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -117,6 +117,12 @@ module.exports = {
 
             const wwwDir = path.join(project_dir, 'www');
 
+            // First: Install the Cordova Electron plugin dependencies
+            execa('npm', ['install'], {
+                cwd: electronPluginSrc
+            });
+
+            // Second: Install the Cordova Electron plugin to the Electron app scope. (npm 8 creates symlink)
             execa('npm', ['install', electronPluginSrc], {
                 cwd: wwwDir
             });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Installing Cordova Electron plugins does not install the Electron scope dependencies since npm 8.

Might be related to: https://github.com/npm/cli/issues/2339

### Description
<!-- Describe your changes in detail -->

This PR will `npm install` the sub-package dependencies before installing the sub-package to the Electron app scope.

The only potential side-efect is a slight increase in performance, but this resolves the changes that were made in npm 7 or 8.

npm 8 will only create a symlink to the sub-package without installing.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- `cordova run` with `cordova-plugin-device` installed.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
