### PR TITLE
feat: support custom Electron version

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -20,7 +20,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const events = require('cordova-common').events;
-const { deepMerge } = require('./util');
+const { deepMerge, getInstalledElectronVersion } = require('./util');
 
 const PLATFORM_MAPPING = {
     linux: 'linux',
@@ -321,6 +321,7 @@ class ElectronBuilder {
     injectProjectConfigToBuildSettings () {
         // const isDevelopment = false;
         const packageJson = require(path.join(this.api.locations.www, 'package.json'));
+
         const userConfig = {
             APP_ID: packageJson.name,
             APP_TITLE: packageJson.displayName,
@@ -328,7 +329,8 @@ class ElectronBuilder {
             APP_BUILD_DIR: this.api.locations.build,
             APP_BUILD_RES_DIR: this.api.locations.buildRes,
             APP_WWW_DIR: this.api.locations.www,
-            BUILD_TYPE: this.isDevelopment ? 'development' : 'distribution'
+            BUILD_TYPE: this.isDevelopment ? 'development' : 'distribution',
+            ELECTRON_INSTALLED_VERSION: getInstalledElectronVersion()
         };
 
         // convert to string for string replacement

--- a/lib/build/base.json
+++ b/lib/build/base.json
@@ -8,10 +8,10 @@
       "buildResources": "${APP_BUILD_RES_DIR}",
       "output": "${APP_BUILD_DIR}"
     },
-    "electronVersion": "14.2.9",
+    "electronVersion": "${ELECTRON_INSTALLED_VERSION}",
 
     "electronDownload": {
-      "version": "14.2.9"
+      "version": "${ELECTRON_INSTALLED_VERSION}"
     }
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,5 +63,5 @@ module.exports.getPackageJson = () => {
  * @return {String} version of installed Electron dependency
  */
 module.exports.getInstalledElectronVersion = () => {
-    return require(require.resolve('electron/package.json')).version;
+    return require('electron/package.json').version;
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,3 +56,12 @@ module.exports.getPackageJson = () => {
 
     return _packageJson;
 };
+
+/**
+ * Gets the installed Electron version from the Electron dependency package.json file.
+ *
+ * @return {String} version of installed Electron dependency
+ */
+module.exports.getInstalledElectronVersion = () => {
+    return require(require.resolve('electron/package.json')).version;
+};

--- a/tests/spec/unit/lib/build.spec.js
+++ b/tests/spec/unit/lib/build.spec.js
@@ -140,15 +140,17 @@ describe('Testing build.js:', () => {
             const buildOptions = { debug: true, buildConfig, argv: [] };
 
             // create spies
+            const getInstalledElectronVersionSpy = jasmine.createSpy('getInstalledElectronVersion').and.returnValue('1.33.7');
             existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
             requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
             build.__set__('fs', { existsSync: existsSyncSpy });
-            build.__set__({ require: requireSpy });
+            build.__set__({ require: requireSpy, getInstalledElectronVersion: getInstalledElectronVersionSpy });
 
             electronBuilder = new ElectronBuilder(buildOptions, api).configure();
 
             expect(existsSyncSpy).toHaveBeenCalled();
             expect(requireSpy).toHaveBeenCalled();
+            expect(getInstalledElectronVersionSpy).toHaveBeenCalled();
             expect(electronBuilder.buildSettings).toEqual(buildConfig);
         });
 
@@ -167,15 +169,17 @@ describe('Testing build.js:', () => {
             const buildOptions = { debug: false, buildConfig, argv: [] };
 
             // create spies
+            const getInstalledElectronVersionSpy = jasmine.createSpy('getInstalledElectronVersion').and.returnValue('1.33.7');
             existsSyncSpy = jasmine.createSpy('existsSync').and.returnValue(true);
             requireSpy = jasmine.createSpy('require').and.returnValue(buildConfig);
             build.__set__('fs', { existsSync: existsSyncSpy });
-            build.__set__({ require: requireSpy });
+            build.__set__({ require: requireSpy, getInstalledElectronVersion: getInstalledElectronVersionSpy });
 
             electronBuilder = new ElectronBuilder(buildOptions, api).configure();
 
             expect(existsSyncSpy).toHaveBeenCalled();
             expect(requireSpy).toHaveBeenCalled();
+            expect(getInstalledElectronVersionSpy).toHaveBeenCalled();
             expect(electronBuilder.buildSettings).toEqual(buildConfig);
         });
 

--- a/tests/spec/unit/lib/util.spec.js
+++ b/tests/spec/unit/lib/util.spec.js
@@ -55,4 +55,13 @@ describe('Testing util.js:', () => {
             expect({}.hoge).toBe(undefined);
         });
     });
+
+    describe('getInstalledElectronVersion method', () => {
+        it('should have a version', () => {
+            const actual = util.getInstalledElectronVersion();
+
+            expect(actual).not.toBe(null);
+            expect(actual).not.toBe(undefined);
+        });
+    });
 });


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support the ability to set custom Electron version.

Closes #185

### Description
<!-- Describe your changes in detail -->

Sometimes developers may want to:
* use a newer versions of Electron that we do not support.
  * Cordova does not support using versions that are defined outside of the default major version range. Using anything outside of the default major range will be considered unsupported. The ability to major bump is for experimental purposes. Use at own risk.
* force pin a version for consistency across environments (development & ci).
* force pin a version to bypass a version that might contain critical bugs or reported security concerns.

#### How to set custom version

**The requirements:**

* For this feature to work, development environment must have npm 8 or greater installed. 
  * npm 8 is provided by default with Node 16 and higher.
  * npm 8 may be installed on older version by running `npm i -g npm@latest`

_note: It is always recommended to keep the environment tooling up-to-date and as of this PR, Node 16 is in Active LTS and Node 18 is current._

**The setup/configuration**

In `package.json` set the `overrides` property.

E.g.

```json
"overrides": {
  "cordova-electron": {
    "electron": "14.2.0",
  }
}
```

**The workings**

NPM 8 has introduced the ability to override sub-package's dependencies. Since Cordova-Electron uses the Electron package for running the project, `cordova run`, this override can be used to control what version is installed.

Additionally, the build script has been updated to extract the installed Electron package version to pass to the Electron Builder. This will ensure that the `cordova run` and the build app from `cordova build` will use the same version of Electron.

### Testing
<!-- Please describe in detail how you tested your changes. -->

* `npm t`
* `cordova platform add`
* `cordova build electron`
* `cordova run electron --nobuild`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
