### PR TITLE
GH-240 electron: Allow passing all platform options to electron-builder

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -68,15 +68,6 @@ class ElectronBuilder {
                     continue;
                 }
 
-                /**
-                 * Validate that the platform configuration properties provided are valid.
-                 * Any invalid property will be warned and iggnored.
-                 * If there is there are no valid properties
-                 */
-                if (!this.__validateUserPlatformBuildSettings(platformConfigs)) {
-                    throw Error(`The platform "${platform}" contains an invalid property. Valid properties are: package, arch, signing`);
-                }
-
                 // Electron uses "win" as it's key, not "windows", so we will update here. We use windows in our settings for clarity.
                 this.__formatAppendUserSettings(
                     (platform === 'windows' ? 'win' : platform),
@@ -247,14 +238,6 @@ class ElectronBuilder {
         if (platform === 'win' && config) {
             this.__appendWindowsUserSigning(config, userBuildSettings.config.win);
         }
-    }
-
-    __validateUserPlatformBuildSettings (platformConfigs) {
-        return !!(
-            platformConfigs.package ||
-            platformConfigs.arch ||
-            platformConfigs.signing
-        );
     }
 
     __appendMacUserSigning (config, buildConfigs) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Electron (Mac/Win/Linux)


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #240.
`electron-builder` allows options to be passed which enable auto-updating, among other things.
Cordova-Electron was unnecessarily restricting the passing of options in the platform configs which prevented the use of these extra configuration options and features of `electron-builder`.

The tests for cordova-electron were not catching this as they only tested each individual unit rather than the integrated code-flow.


### Description
<!-- Describe your changes in detail -->
Removing the function `__validateUserPlatformBuildSettings` and it's call in `lib/build.js` enables the use of these extra config keys. Any errors caused by incorrect config keys should be caught by `electron-builder` itself, negating the need for this check.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
