### PR TITLE
Added possibility for multiple plugin results

### DIFF
--- a/bin/templates/platform_www/CallbackContext.js
+++ b/bin/templates/platform_www/CallbackContext.js
@@ -1,0 +1,40 @@
+class PluginResult {
+  static STATUS_OK = 'OK'
+  static STATUS_ERROR = 'ERROR'
+  static ERROR_UNKNOWN_SERVICE = 'ERR_UNKNOWN_SERVICE'
+  static ERROR_UNKNOWN_ACTION = 'ERR_UNKNOWN_ACTION'
+  static ERROR_UNEXPECTED_RESULT = 'ERR_UNEXPECTED_RESULT'
+  static ERROR_INVOCATION_EXCEPTION_NODE = 'ERROR_INVOCATION_EXCEPTION_NODE'
+  static ERROR_INVOCATION_EXCEPTION_CHROME = 'ERROR_INVOCATION_EXCEPTION_CHROME'
+  keepCallback = false;
+
+  constructor(status, data) {
+    this.status = status;
+    this.data = data !== undefined ? data : null;
+  }
+
+  setKeepCallback(value) {
+    this.keepCallback = value;
+  }
+}
+
+class CallbackContext {
+
+  constructor(contextId, window) {
+    this.contextId = contextId;
+    this.window = window;
+    // add PluginResult as instance variable to be able to access it in plugins
+    this.PluginResult = PluginResult;
+  }
+  sendPluginResult(result) {
+    this.window.webContents.send(this.contextId, result)
+  }
+  success(data) {
+    this.sendPluginResult(new PluginResult(PluginResult.STATUS_OK, data))
+  }
+  error(data) {
+    this.sendPluginResult(new PluginResult(PluginResult.STATUS_ERROR, data))
+  }
+}
+
+module.exports = { CallbackContext, PluginResult };

--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -39,9 +39,10 @@ const execProxy = require('cordova/exec/proxy');
  * @param {String[]} [args]     Zero or more arguments to pass to the method
  */
 module.exports = function (success, fail, service, action, args) {
+    const callbackId = service + cordova.callbackId++;
     if (window._cdvElectronIpc.hasService(service)) {
         // Electron based plugin support
-        window._cdvElectronIpc.exec(success, fail, service, action, args);
+        window._cdvElectronIpc.exec(success, fail, service, action, callbackId, args);
     } else {
         // Fall back for browser based plugin support...
         const proxy = execProxy.get(service, action);
@@ -49,8 +50,6 @@ module.exports = function (success, fail, service, action, args) {
         args = args || [];
 
         if (proxy) {
-            const callbackId = service + cordova.callbackId++;
-
             if (typeof success === 'function' || typeof fail === 'function') {
                 cordova.callbacks[callbackId] = { success: success, fail: fail };
             }
@@ -96,13 +95,14 @@ module.exports = function (success, fail, service, action, args) {
                 };
                 proxy(onSuccess, onError, args);
             } catch (e) {
-                console.log('Exception calling native with command :: ' + service + ' :: ' + action + ' ::exception=' + e);
+                console.error(`Exception when calling fallback browser action '${action}' on service '${service}'`, e);
             }
         } else {
-            console.log('Error: exec proxy not found for :: ' + service + ' :: ' + action);
+            const message = `Could not call electron action '${action}' on service '${service}'; Service is not registered`;
+            console.error(message);
 
             if (typeof fail === 'function') {
-                fail('Missing Command Error');
+                fail(message);
             }
         }
     }

--- a/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/plugin.xml
+++ b/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/plugin.xml
@@ -18,23 +18,28 @@
   under the License.
 -->
 
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    id="cordova-plugin-sample"
-    version="1.0.0">
-    <name>Sanple</name>
-    <description>Cordova Sample Plugin</description>
-    <license>Apache 2.0</license>
-    <keywords>cordova,sample</keywords>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-sample" version="1.0.0">
+  <name>Sanple</name>
+  <description>Cordova Sample Plugin</description>
+  <license>Apache 2.0</license>
+  <keywords>cordova,sample</keywords>
 
-    <engines>
-        <engine name="cordova-electron" version=">=3.0.0" />
-    </engines>
+  <engines>
+    <engine name="cordova-electron" version=">=3.0.0" />
+  </engines>
 
-    <js-module src="www/sample.js" name="sample">
-        <clobbers target="sample" />
+  <js-module src="www/init.js" name="initializer">
+    <runs/>
+  </js-module>
+
+
+  <platform name="electron">
+    <framework src="src/electron" />
+  </platform>
+
+  <platform name="browser">
+    <js-module src="src/browser/sample.js" name="bsample">
+      <runs />
     </js-module>
-
-    <platform name="electron">
-        <framework src="src/electron" />
-    </platform>
+  </platform>
 </plugin>

--- a/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/src/browser/sample.js
+++ b/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/src/browser/sample.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testLocation() {
+    return window.location;
+  },
+  testEchoBrowser(args) {
+    return "BROWSER: echo1 is: " + args[1];
+  }
+}

--- a/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/www/init.js
+++ b/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/www/init.js
@@ -1,0 +1,55 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+document.addEventListener("deviceready", () => {
+    const tests = {
+        testProcess: null,
+        testLocation: null,
+        testMany: null,
+        testError: null,
+        testEchoElectron: ['echo', 'echoo', 'echooo'],
+        testEchoBrowser: ['echo', 'echoo', 'echooo'],
+        testUnknownAction: ['echo', 'echoo', 'echooo']
+    }
+    for(let test in tests) {
+        cordova.exec(
+            data => {
+                console.log(`${test} success callback`, data)
+            },
+            error => {
+                console.log(`${test} error callback`, error)
+            },
+            'Sample',
+            test,
+            tests[test]
+        );
+    }
+
+    cordova.exec(
+        data => {
+            console.log(`UnkonwService success callback`, data)
+        },
+        error => {
+            console.log(`UnkonwService error callback`, error)
+        },
+        'UnknownService',
+        'irrelevant'
+    );
+});


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
electron
browser (?)


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It is currently not possible to send more than one plugin response per service action call. This is not ideal in situations where a native process might generate more than one result over time.
Additionally, the API is more in line with that of cordova-android and from what I can gather also cordova-ios



### Description
<!-- Describe your changes in detail -->
The version in this branch creates a callbackId in exec.js and passes it on to preload.
preload registers this callbackId with ipcRenderer and invokes the callback.
main creates a CallbackContext with this callbackId and passes it on to the service action dispatch
service actions now have a similar API as android: (action: string, args: any, callbackContext: Object)

[callbackContext]https://github.com/teh-mICON/cordova-electron/blob/4.0.x/bin/templates/platform_www/CallbackContext.js#L21) provides functions `success` and `error`.
Additionally, it exposes the `PluginResult` class along with `sendPluginResult`. This makes it possible to send multiple results when keepCallback is set to true.
There might be a better way to provide this API to plugins.




### Testing
<!-- Please describe in detail how you tested your changes. -->
I used document.addEventListener in the [plugin sample](https://github.com/teh-mICON/cordova-electron/blob/4.0.x/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/www/init.js) to call [a demo implementation of the new api]((https://github.com/teh-mICON/cordova-electron/blob/4.0.x/tests/spec/fixtures/test-app-with-electron-plugin/plugins/cordova-plugin-sample/src/electron/index.js)



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary

Unfortunately I can't check any of these. I wasn't sure how the tests were supposed to be run but I created a sample app that tests for the functionality.

### Additional notes
- The API changes would break existing plugins but it would be a new major version so depending on the maintainer's opinions that might be ok?
If not, there is always the option to load the plugin package.json and check for an API flag.
- I couldn't get the browser fallback to work so couldn't test for that.
- Strictly speaking it applies to both electron and browser so the check is alright in that box I guess
- I didn't find any documentation that applies