### PR TITLE
fix!: remove extra array wrapper from passed arguments

### DIFF
--- a/bin/templates/platform_www/cdv-electron-main.js
+++ b/bin/templates/platform_www/cdv-electron-main.js
@@ -169,7 +169,7 @@ ipcMain.handle('cdv-plugin-exec', async (_, serviceName, action, ...args) => {
         const plugin = require(cordova.services[serviceName]);
 
         return plugin[action]
-            ? plugin[action](args)
+            ? plugin[action](...args)
             : Promise.reject(new Error(`The action "${action}" for the requested plugin service "${serviceName}" does not exist.`));
     } else {
         return Promise.reject(new Error(`The requested plugin service "${serviceName}" does not exist have native support.`));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

electron

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Arguments passed to plugins were accidentally being double-wrapped. This update properly removes the wrapping so that plugin developers don't always have to read from index [0]. Additionally, other platforms did not have this double wrapping.

### Description
<!-- Describe your changes in detail -->

Updated the IPC handler to expand the args that are passed to plugins.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`
- `cordova build electron`
- `cordova run electron --nobuild`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
