### PR TITLE
refactor: use node internal modules & replace fs-extra with node:fs

### DIFF
--- a/bin/templates/platform_www/cdv-electron-main.js
+++ b/bin/templates/platform_www/cdv-electron-main.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs');
+const fs = require('node:fs');
 const path = require('node:path');
 const { cordova } = require('./package.json');
 // Module to control application life, browser window and tray.

--- a/bin/templates/platform_www/cdv-electron-main.js
+++ b/bin/templates/platform_www/cdv-electron-main.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('fs');
-const path = require('path');
+const path = require('node:path');
 const { cordova } = require('./package.json');
 // Module to control application life, browser window and tray.
 const {

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -22,7 +22,7 @@
     'cordova platform add PATH' where path is this repo.
 */
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const {
     ActionStack,
     ConfigChanges: { PlatformMunger },
@@ -190,7 +190,7 @@ class Api {
                 this._removeModulesInfo(pluginInfo, targetDir);
                 // Remove stale plugin directory
                 // @todo this should be done by plugin files uninstaller
-                fs.removeSync(path.resolve(this.root, 'Plugins', pluginInfo.id));
+                fs.rmSync(path.resolve(this.root, 'Plugins', pluginInfo.id), { recursive: true, force: true });
             });
     }
 
@@ -303,8 +303,8 @@ class Api {
             // BOTTOM OF METADATA
         });`;
 
-        fs.ensureDirSync(targetDir);
-        fs.writeFileSync(path.join(targetDir, 'cordova_plugins.js'), final_contents, 'utf-8');
+        fs.mkdirSync(targetDir, { recursive: true });
+        fs.writeFileSync(path.join(targetDir, 'cordova_plugins.js'), final_contents, 'utf8');
     }
 
     /**

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -21,7 +21,7 @@
     this file is found by cordova-lib when you attempt to
     'cordova platform add PATH' where path is this repo.
 */
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const {
     ActionStack,

--- a/lib/ManifestJsonParser.js
+++ b/lib/ManifestJsonParser.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 
 class ManifestJsonParser {
@@ -91,7 +91,7 @@ class ManifestJsonParser {
 
             if (fs.existsSync(startUrlPath)) {
                 // fetch start url file content and parse for theme-color.
-                const contents = fs.readFileSync(startUrlPath, 'utf-8');
+                const contents = fs.readFileSync(startUrlPath, 'utf8');
                 const result = /<meta(?=[^>]*name="theme-color")\s[^>]*content="([^>]*)"/i.exec(contents);
 
                 // If theme-color exists, the value is in index 1.

--- a/lib/ManifestJsonParser.js
+++ b/lib/ManifestJsonParser.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 
 class ManifestJsonParser {
     constructor (wwwDir) {

--- a/lib/PackageJsonParser.js
+++ b/lib/PackageJsonParser.js
@@ -17,15 +17,24 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const { getPackageJson } = require('./util');
 
 class PackageJsonParser {
     constructor (wwwDir, projectRootDir) {
-        // Electron App Package
+        // make sure www dir exists
+        if (!fs.existsSync(wwwDir)) {
+            fs.mkdirSync(wwwDir, { recursive: true });
+        }
+
         this.path = path.join(wwwDir, 'package.json');
-        fs.ensureFileSync(this.path);
+
+        if (!fs.existsSync(this.path)) {
+            fs.writeFileSync(this.path, '{}', 'utf8');
+        }
+
+        // Electron App Package
         this.package = JSON.parse(fs.readFileSync(this.path, 'utf8') || '{}');
 
         // Force settings that are not allowed to change.

--- a/lib/PackageJsonParser.js
+++ b/lib/PackageJsonParser.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const { getPackageJson } = require('./util');
 
 class PackageJsonParser {

--- a/lib/SettingJsonParser.js
+++ b/lib/SettingJsonParser.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const { deepMerge } = require('./util');
 
 class SettingJsonParser {

--- a/lib/SettingJsonParser.js
+++ b/lib/SettingJsonParser.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const { deepMerge } = require('./util');
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const events = require('cordova-common').events;
 const { deepMerge, getInstalledElectronVersion } = require('./util');
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const events = require('cordova-common').events;
 const { deepMerge, getInstalledElectronVersion } = require('./util');

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const check_reqs = require('./check_reqs');
 const platformBuildDir = path.join('platforms', 'electron', 'www');
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const check_reqs = require('./check_reqs');
 const platformBuildDir = path.join('platforms', 'electron', 'www');
@@ -32,7 +32,7 @@ module.exports.run = () => {
 
     try {
         if (fs.existsSync(platformBuildDir)) {
-            fs.removeSync(platformBuildDir);
+            fs.rmSync(platformBuildDir, { recursive: true, force: true });
         }
     } catch (err) {
         console.log(`could not remove ${platformBuildDir} : ${err.message}`);

--- a/lib/create.js
+++ b/lib/create.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const rootDir = path.resolve(__dirname, '..');
 const events = require('cordova-common').events;
@@ -46,10 +46,10 @@ module.exports.createProject = (platform_dir, package_name, project_name, option
     }
 
     // Make sure that the platform directory is created if missing.
-    fs.ensureDirSync(platform_dir);
+    fs.mkdirSync(platform_dir, { recursive: true });
 
     // copy templates directory to the platform directory recursively
-    fs.copySync(path.join(rootDir, 'bin/templates'), path.join(platform_dir), { overwrite: false });
+    fs.cpSync(path.join(rootDir, 'bin/templates'), path.join(platform_dir), { recursive: true, force: true });
 
     return Promise.resolve();
 };

--- a/lib/create.js
+++ b/lib/create.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const rootDir = path.resolve(__dirname, '..');
 const events = require('cordova-common').events;
 const check_reqs = require(path.join(rootDir, 'lib/check_reqs'));

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -18,7 +18,7 @@
 */
 
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const execa = require('execa');
 const { events } = require('cordova-common');
 const { _orderObject } = require('./PackageJsonParser');
@@ -53,7 +53,7 @@ module.exports = {
             const moduleName = `${plugin_id}.${jsModule.name || path.basename(jsModule.src, path.extname(jsModule.src))}`;
 
             // Read in the file, prepend the cordova.define, and write it back out.
-            let scriptContent = fs.readFileSync(moduleSource, 'utf-8').replace(/^\ufeff/, ''); // Window BOM
+            let scriptContent = fs.readFileSync(moduleSource, 'utf8').replace(/^\ufeff/, ''); // Window BOM
 
             if (moduleSource.match(/.*\.json$/)) {
                 scriptContent = `module.exports =  + ${scriptContent}`;
@@ -65,11 +65,11 @@ module.exports = {
 
             const moduleDestination = path.resolve(www_dir, 'plugins', plugin_id, jsModule.src);
 
-            fs.ensureDirSync(path.dirname(moduleDestination));
-            fs.writeFileSync(moduleDestination, scriptContent, 'utf-8');
+            fs.mkdirSync(path.dirname(moduleDestination), { recursive: true });
+            fs.writeFileSync(moduleDestination, scriptContent, 'utf8');
         },
         uninstall: (jsModule, www_dir, plugin_id) => {
-            fs.removeSync(path.join(www_dir, 'plugins', plugin_id));
+            fs.rmSync(path.join(www_dir, 'plugins', plugin_id), { recursive: true, force: true });
             const pluginRelativePath = path.join('plugins', plugin_id, jsModule.src);
             // common.removeFileAndParents(www_dir, pluginRelativePath);
             events.emit('verbose', `js-module uninstall called : ${pluginRelativePath}`);
@@ -226,12 +226,12 @@ module.exports = {
             const dest = path.join(wwwDest, asset.target);
             const destDir = path.parse(dest).dir;
 
-            fs.ensureDirSync(destDir);
-            fs.copySync(src, dest);
+            fs.mkdirSync(destDir, { recursive: true });
+            fs.cpSync(src, dest, { recursive: true });
         },
         uninstall: (asset, wwwDest, plugin_id) => {
-            fs.removeSync(path.join(wwwDest, asset.target));
-            fs.removeSync(path.join(wwwDest, 'plugins', plugin_id));
+            fs.rmSync(path.join(wwwDest, asset.target), { recursive: true, force: true });
+            fs.rmSync(path.join(wwwDest, 'plugins', plugin_id), { recursive: true, force: true });
         }
     }
 };

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const execa = require('execa');
 const { events } = require('cordova-common');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const CordovaError = require('cordova-common').CordovaError;
 const events = require('cordova-common').events;
 const FileUpdater = require('cordova-common').FileUpdater;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const CordovaError = require('cordova-common').CordovaError;
 const events = require('cordova-common').events;
@@ -79,7 +79,7 @@ class Parser {
         return this.update_from_config()
             .then(
                 // Copy munged config.xml to platform www dir
-                () => fs.copySync(path.join(this.www_dir(), '..', 'config.xml'), path.join(this.www_dir(), 'config.xml'))
+                () => fs.cpSync(path.join(this.www_dir(), '..', 'config.xml'), path.join(this.www_dir(), 'config.xml'), { recursive: true })
             );
     }
 }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const { ConfigParser, xmlHelpers, events, CordovaError } = require('cordova-common');
 const ManifestJsonParser = require('./ManifestJsonParser');
@@ -35,13 +35,13 @@ module.exports.prepare = function (cordovaProject, options) {
     // restored or copy project config into platform if none exists.
     if (fs.existsSync(defaultConfigPath)) {
         this.events.emit('verbose', `Generating config.xml from defaults for platform "${this.platform}"`);
-        fs.copySync(defaultConfigPath, ownConfigPath);
+        fs.cpSync(defaultConfigPath, ownConfigPath, { recursive: true });
     } else if (fs.existsSync(ownConfigPath)) {
         this.events.emit('verbose', `Generating defaults.xml from own config.xml for platform "${this.platform}"`);
-        fs.copySync(ownConfigPath, defaultConfigPath);
+        fs.cpSync(ownConfigPath, defaultConfigPath, { recursive: true });
     } else {
         this.events.emit('verbose', `case 3 "${this.platform}"`);
-        fs.copySync(sourceCfg.path, ownConfigPath);
+        fs.cpSync(sourceCfg.path, ownConfigPath, { recursive: true });
     }
 
     // merge our configs
@@ -63,7 +63,7 @@ module.exports.prepare = function (cordovaProject, options) {
         // todo: validate it? ensure all properties we expect exist?
         const manifestPath = path.join(this.locations.www, 'manifest.json');
         this.events.emit('verbose', `Copying ${srcManifestPath} => ${manifestPath}`);
-        fs.copySync(srcManifestPath, manifestPath);
+        fs.cpSync(srcManifestPath, manifestPath, { recursive: true });
     } else {
         this.events.emit('verbose', `Creating new manifest file in => ${this.path}`);
 
@@ -345,7 +345,7 @@ function copyResources (rootDir, resourceMap) {
 
         if (elementKeys.length) {
             const value = elementKeys.map((e) => element[e])[0];
-            fs.copySync(path.join(rootDir, elementKeys[0]), value);
+            fs.cpSync(path.join(rootDir, elementKeys[0]), value, { recursive: true });
         }
     });
 }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const { ConfigParser, xmlHelpers, events, CordovaError } = require('cordova-common');
 const ManifestJsonParser = require('./ManifestJsonParser');
 const PackageJsonParser = require('./PackageJsonParser');

--- a/lib/run.js
+++ b/lib/run.js
@@ -19,7 +19,7 @@
 
 const electron = require('electron');
 const execa = require('execa');
-const path = require('path');
+const path = require('node:path');
 
 module.exports.run = function (args = {}) {
     const electonArgs = args.argv || [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "electron": "^29.0.0",
         "electron-builder": "^24.12.0",
         "electron-devtools-installer": "^3.2.0",
-        "execa": "^5.1.1",
-        "fs-extra": "^11.2.0"
+        "execa": "^5.1.1"
       },
       "devDependencies": {
         "@cordova/eslint-config": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "electron": "^29.0.0",
     "electron-builder": "^24.12.0",
     "electron-devtools-installer": "^3.2.0",
-    "execa": "^5.1.1",
-    "fs-extra": "^11.2.0"
+    "execa": "^5.1.1"
   },
   "devDependencies": {
     "@cordova/eslint-config": "^5.0.0",

--- a/tests/spec/unit/lib/Api.spec.js
+++ b/tests/spec/unit/lib/Api.spec.js
@@ -18,7 +18,7 @@
 */
 
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const rewire = require('rewire');
 const { events, PluginInfo, ConfigParser, CordovaError } = require('cordova-common');
 

--- a/tests/spec/unit/lib/Api.spec.js
+++ b/tests/spec/unit/lib/Api.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const rewire = require('rewire');
 const { events, PluginInfo, ConfigParser, CordovaError } = require('cordova-common');
@@ -62,15 +62,15 @@ describe('Api class', () => {
     let apiEvents;
 
     beforeAll(() => {
-        fs.ensureDirSync(tmpDir);
-        fs.copySync(path.resolve(fixturesDir, 'testapp'), testProjectDir);
+        fs.mkdirSync(tmpDir, { recursive: true });
+        fs.cpSync(path.resolve(fixturesDir, 'testapp'), testProjectDir, { recursive: true });
 
         apiEvents = Api.__get__('selfEvents');
         apiEvents.addListener('verbose', (data) => { });
     });
 
     afterAll(() => {
-        fs.removeSync(tmpDir);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
         apiEvents.removeAllListeners();
     });
 
@@ -152,13 +152,13 @@ describe('Api class', () => {
         beforeEach(() => {
             spyOn(events, 'emit');
 
-            fs.removeSync(path.resolve(testProjectDir, 'electron.json'));
-            fs.removeSync(path.resolve(testProjectDir, 'www'));
+            fs.rmSync(path.resolve(testProjectDir, 'electron.json'), { recursive: true, force: true });
+            fs.rmSync(path.resolve(testProjectDir, 'www'), { recursive: true, force: true });
         });
 
         afterEach(() => {
-            fs.removeSync(path.resolve(testProjectDir, 'electron.json'));
-            fs.removeSync(path.resolve(testProjectDir, 'www'));
+            fs.rmSync(path.resolve(testProjectDir, 'electron.json'), { recursive: true, force: true });
+            fs.rmSync(path.resolve(testProjectDir, 'www'), { recursive: true, force: true });
 
             apiEvents.removeAllListeners();
         });
@@ -208,14 +208,14 @@ describe('Api class', () => {
             });
 
             it('should have "clobber", "merge", and "run" set when defined in "js-module".', () => {
-                const { modules } = fs.readJsonSync(path.resolve(testProjectDir, 'electron.json'));
+                const { modules } = JSON.parse(fs.readFileSync(path.resolve(testProjectDir, 'electron.json'), 'utf8'));
                 expect(modules[0].clobbers).toBeDefined();
                 expect(modules[0].merges).toBeDefined();
                 expect(modules[0].runs).toBeDefined();
             });
 
             it('should have module id containing the name attribute value.', () => {
-                const { modules } = fs.readJsonSync(path.resolve(testProjectDir, 'electron.json'));
+                const { modules } = JSON.parse(fs.readFileSync(path.resolve(testProjectDir, 'electron.json'), 'utf8'));
                 expect(modules[0].id).toBe('org.apache.testplugin.TestPlugin');
             });
         });
@@ -228,14 +228,14 @@ describe('Api class', () => {
             });
 
             it('should not have "clobber", "merge", and "run" set when not defined in "js-module".', () => {
-                const { modules } = fs.readJsonSync(path.resolve(testProjectDir, 'electron.json'));
+                const { modules } = JSON.parse(fs.readFileSync(path.resolve(testProjectDir, 'electron.json'), 'utf8'));
                 expect(modules[0].clobbers).not.toBeDefined();
                 expect(modules[0].merges).not.toBeDefined();
                 expect(modules[0].runs).not.toBeDefined();
             });
 
             it('should use js filename for plugin id if name is missing.', () => {
-                const { modules } = fs.readJsonSync(path.resolve(testProjectDir, 'electron.json'));
+                const { modules } = JSON.parse(fs.readFileSync(path.resolve(testProjectDir, 'electron.json'), 'utf8'));
                 expect(modules[0].id).toBe('org.apache.testplugin2.MyTestPlugin2');
             });
         });
@@ -250,7 +250,7 @@ describe('Api class', () => {
             });
 
             it('should use custom package name.', () => {
-                const { installed_plugins } = fs.readJsonSync(path.resolve(testProjectDir, 'electron.json'));
+                const { installed_plugins } = JSON.parse(fs.readFileSync(path.resolve(testProjectDir, 'electron.json'), 'utf8'));
                 expect(installed_plugins['org.apache.testplugin'].PACKAGE_NAME).toEqual('com.foobar.newpackagename');
             });
 
@@ -293,13 +293,13 @@ describe('Api class', () => {
         beforeEach(() => {
             spyOn(events, 'emit');
 
-            fs.removeSync(path.resolve(testProjectDir, 'electron.json'));
-            fs.removeSync(path.resolve(testProjectDir, 'www'));
+            fs.rmSync(path.resolve(testProjectDir, 'electron.json'), { recursive: true, force: true });
+            fs.rmSync(path.resolve(testProjectDir, 'www'), { recursive: true, force: true });
         });
 
         afterEach(() => {
-            fs.removeSync(path.resolve(testProjectDir, 'electron.json'));
-            fs.removeSync(path.resolve(testProjectDir, 'www'));
+            fs.rmSync(path.resolve(testProjectDir, 'electron.json'), { recursive: true, force: true });
+            fs.rmSync(path.resolve(testProjectDir, 'www'), { recursive: true, force: true });
 
             apiEvents.removeAllListeners();
         });
@@ -331,7 +331,7 @@ describe('Api class', () => {
             it('should remove the empty plugin data from electron.json.', () => {
                 return api.removePlugin(pluginInfo).then(
                     () => {
-                        const { plugin_metadata, modules, installed_plugins } = fs.readJsonSync(path.resolve(testProjectDir, 'electron.json'));
+                        const { plugin_metadata, modules, installed_plugins } = JSON.parse(fs.readFileSync(path.resolve(testProjectDir, 'electron.json'), 'utf8'));
                         expect(plugin_metadata).toEqual({});
                         expect(modules).toEqual([]);
                         expect(installed_plugins).toEqual({});
@@ -452,12 +452,12 @@ describe('Api prototype methods', () => {
         let config;
 
         beforeEach(() => {
-            fs.removeSync(tmpDir);
+            fs.rmSync(tmpDir, { recursive: true, force: true });
             config = new ConfigParser(path.join(fixturesDir, 'test-config-empty.xml'));
         });
 
         afterEach(() => {
-            fs.removeSync(tmpDir);
+            fs.rmSync(tmpDir, { recursive: true, force: true });
         });
 
         it('should create cordova project at the provided destination', () => {

--- a/tests/spec/unit/lib/ManifestJsonParser.spec.js
+++ b/tests/spec/unit/lib/ManifestJsonParser.spec.js
@@ -18,7 +18,7 @@
 */
 
 const rewire = require('rewire');
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const { ConfigParser } = require('cordova-common');
 

--- a/tests/spec/unit/lib/ManifestJsonParser.spec.js
+++ b/tests/spec/unit/lib/ManifestJsonParser.spec.js
@@ -19,7 +19,7 @@
 
 const rewire = require('rewire');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const { ConfigParser } = require('cordova-common');
 
 const rootDir = path.resolve(__dirname, '../../../..');

--- a/tests/spec/unit/lib/PackageJsonParser.spec.js
+++ b/tests/spec/unit/lib/PackageJsonParser.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const os = require('node:os');
 const { ConfigParser, events } = require('cordova-common');

--- a/tests/spec/unit/lib/PackageJsonParser.spec.js
+++ b/tests/spec/unit/lib/PackageJsonParser.spec.js
@@ -18,14 +18,14 @@
 */
 
 const path = require('path');
-const fs = require('fs-extra');
-const rewire = require('rewire');
+const fs = require('node:fs');
+const os = require('node:os');
 const { ConfigParser, events } = require('cordova-common');
 
 const rootDir = path.resolve(__dirname, '../../../..');
 const fixturesDir = path.join(rootDir, 'tests/spec/fixtures');
 
-const PackageJsonParser = rewire(path.join(rootDir, 'lib/PackageJsonParser'));
+const PackageJsonParser = require(path.join(rootDir, 'lib/PackageJsonParser'));
 
 // Create a real config object before mocking out everything.
 const cfg = new ConfigParser(path.join(fixturesDir, 'test-config-1.xml'));
@@ -50,24 +50,28 @@ const defaultMockProjectPackageJson = {
     }
 };
 
-const locations = {
-    buildRes: path.join('mock', 'build-res'),
-    www: path.join('mock', 'www'),
-    configXml: path.join('mock', 'config.xml')
-};
-
 const defaultInitPackageObj = { main: 'cdv-electron-main.js' };
 
 describe('PackageJsonParser class', () => {
     let packageJsonParser;
+    let locations;
+    let tmpDir;
 
     beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cordovaElectronTest-'));
+
+        locations = {
+            buildRes: path.join(tmpDir, 'build-res'),
+            www: path.join(tmpDir, 'www'),
+            configXml: path.join(tmpDir, 'config.xml')
+        };
+
         packageJsonParser = new PackageJsonParser(locations.www, '/root/project');
         spyOn(events, 'emit');
     });
 
     afterAll(() => {
-        fs.removeSync('mock');
+        fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
     it('should have been constructed with initial values.', () => {
@@ -191,5 +195,40 @@ describe('PackageJsonParser class', () => {
             jasmine.stringMatching(/whatever/),
             'utf8'
         );
+    });
+});
+
+describe('PackageJsonParser (2) class', () => {
+    it('should have constructed and already detected directories and files', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cordovaElectronTest-'));
+        const locations = {
+            buildRes: path.join(tmpDir, 'build-res'),
+            www: path.join(tmpDir, 'www'),
+            configXml: path.join(tmpDir, 'config.xml')
+        };
+        const wwwDir = locations.www;
+        const pkgFile = path.join(wwwDir, 'package.json');
+
+        fs.mkdirSync(wwwDir, { recursive: true });
+        fs.writeFileSync(pkgFile, '{}', 'utf8');
+
+        spyOn(events, 'emit');
+        spyOn(fs, 'readFileSync');
+
+        // files & directories should already exisy
+        expect(fs.existsSync(wwwDir)).toBeTruthy();
+        expect(fs.existsSync(pkgFile)).toBeTruthy();
+
+        /* eslint-disable-next-line */
+        const packageJsonParser = new PackageJsonParser(wwwDir, '/root/project');
+
+        expect(fs.readFileSync).toHaveBeenCalled();
+        // There should be no change in truthy values.
+        expect(fs.existsSync(wwwDir)).toBeTruthy();
+        expect(fs.existsSync(pkgFile)).toBeTruthy();
+
+        expect(packageJsonParser.package).toBeDefined();
+
+        fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 });

--- a/tests/spec/unit/lib/SettingJsonParser.spec.js
+++ b/tests/spec/unit/lib/SettingJsonParser.spec.js
@@ -18,7 +18,7 @@
 */
 
 const rewire = require('rewire');
-const path = require('path');
+const path = require('node:path');
 const ConfigParser = require('cordova-common').ConfigParser;
 
 const rootDir = path.resolve(__dirname, '../../../..');

--- a/tests/spec/unit/lib/build.spec.js
+++ b/tests/spec/unit/lib/build.spec.js
@@ -20,7 +20,7 @@
 
 const rewire = require('rewire');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 
 const rootDir = path.resolve(__dirname, '../../../..');
 const fixturesDir = path.join(rootDir, 'tests/spec/fixtures');
@@ -35,13 +35,13 @@ describe('Testing build.js:', () => {
     let api;
 
     beforeAll(() => {
-        fs.ensureDirSync(tmpDir);
-        fs.copySync(path.resolve(fixturesDir, 'testapp'), path.resolve(tmpDir, 'testapp'));
+        fs.mkdirSync(tmpDir, { recursive: true });
+        fs.cpSync(path.resolve(fixturesDir, 'testapp'), path.resolve(tmpDir, 'testapp'), { recursive: true });
         api = new Api(null, testProjectDir);
     });
 
     afterAll(() => {
-        fs.removeSync(tmpDir);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
     beforeEach(() => {

--- a/tests/spec/unit/lib/build.spec.js
+++ b/tests/spec/unit/lib/build.spec.js
@@ -19,7 +19,7 @@
 */
 
 const rewire = require('rewire');
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 
 const rootDir = path.resolve(__dirname, '../../../..');

--- a/tests/spec/unit/lib/clean.spec.js
+++ b/tests/spec/unit/lib/clean.spec.js
@@ -18,7 +18,7 @@
 */
 
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 
 const rootDir = path.resolve(__dirname, '../../../..');
 
@@ -45,30 +45,30 @@ describe('Clean', () => {
         it('should not find previous build dir and not attempt to remove.', () => {
             spyOn(check_reqs, 'run').and.returnValue(true);
             spyOn(fs, 'existsSync').and.returnValue(false);
-            spyOn(fs, 'removeSync');
+            spyOn(fs, 'rmSync');
 
             clean.run();
 
             expect(fs.existsSync).toHaveBeenCalled();
-            expect(fs.removeSync).not.toHaveBeenCalled();
+            expect(fs.rmSync).not.toHaveBeenCalled();
         });
 
         it('should find previous build dir and attempt to remove.', () => {
             spyOn(check_reqs, 'run').and.returnValue(true);
             spyOn(fs, 'existsSync').and.returnValue(true);
-            spyOn(fs, 'removeSync');
+            spyOn(fs, 'rmSync');
 
             clean.run();
 
             expect(fs.existsSync).toHaveBeenCalled();
-            expect(fs.removeSync).toHaveBeenCalled();
+            expect(fs.rmSync).toHaveBeenCalled();
         });
 
         it('should find previous build dir and fail to remove.', () => {
             spyOn(console, 'log');
             spyOn(check_reqs, 'run').and.returnValue(true);
             spyOn(fs, 'existsSync').and.returnValue(true);
-            spyOn(fs, 'removeSync').and.callFake(() => {
+            spyOn(fs, 'rmSync').and.callFake(() => {
                 throw new Error('Fake Error');
             });
 

--- a/tests/spec/unit/lib/clean.spec.js
+++ b/tests/spec/unit/lib/clean.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 
 const rootDir = path.resolve(__dirname, '../../../..');

--- a/tests/spec/unit/lib/create.spec.js
+++ b/tests/spec/unit/lib/create.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const os = require('os');
+const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
 const rewire = require('rewire');

--- a/tests/spec/unit/lib/create.spec.js
+++ b/tests/spec/unit/lib/create.spec.js
@@ -18,7 +18,7 @@
 */
 
 const os = require('os');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const path = require('path');
 const rewire = require('rewire');
 
@@ -37,7 +37,7 @@ describe('create', () => {
         tmpDir = makeTempDir();
     });
     afterEach(() => {
-        fs.removeSync(tmpDir);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
     it('creates a project that has the expected files', () => {
@@ -58,9 +58,9 @@ describe('create', () => {
         const projectPath = path.join(tmpDir, projectname);
 
         create.__set__('fs', {
-            ensureDirSync: fs.ensureDirSync,
+            mkdirSync: fs.mkdirSync,
             existsSync: path => path !== projectPath,
-            copySync: () => true
+            cpSync: () => true
         });
 
         return create.createProject(projectPath, projectname, projectid).then(() => {

--- a/tests/spec/unit/lib/create.spec.js
+++ b/tests/spec/unit/lib/create.spec.js
@@ -19,7 +19,7 @@
 
 const os = require('os');
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const rewire = require('rewire');
 
 const rootDir = path.resolve(__dirname, '../../../..');

--- a/tests/spec/unit/lib/handler.spec.js
+++ b/tests/spec/unit/lib/handler.spec.js
@@ -18,7 +18,7 @@
 */
 
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const { events } = require('cordova-common');
 const rewire = require('rewire');
 
@@ -78,7 +78,7 @@ describe('Handler export', () => {
 
                 // spies
                 spyOn(fs, 'readFileSync').and.returnValue(''); // fake scriptContent
-                spyOn(fs, 'ensureDirSync').and.returnValue(true);
+                spyOn(fs, 'mkdirSync').and.returnValue(true);
                 spyOn(fs, 'writeFileSync');
 
                 handler['js-module'].install(jsModule, plugin_dir, plugin_id, www_dir);
@@ -86,8 +86,8 @@ describe('Handler export', () => {
                 const moduleDetination = path.dirname(path.resolve(www_dir, 'plugins', plugin_id, jsModule.src));
                 const writeFileSyncContent = fs.writeFileSync.calls.argsFor(0)[1];
 
-                expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(plugin_dir, jsModule.src), 'utf-8');
-                expect(fs.ensureDirSync).toHaveBeenCalledWith(moduleDetination);
+                expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(plugin_dir, jsModule.src), 'utf8');
+                expect(fs.mkdirSync).toHaveBeenCalledWith(moduleDetination, { recursive: true });
                 expect(writeFileSyncContent).toContain(`cordova.define('${moduleName}'`);
 
                 return writeFileSyncContent;
@@ -119,12 +119,12 @@ describe('Handler export', () => {
                 const plugin_id = 'com.foo.dummy-plugin';
 
                 // spies
-                spyOn(fs, 'removeSync').and.returnValue(true);
+                spyOn(fs, 'rmSync').and.returnValue(true);
                 spyOn(events, 'emit');
 
                 handler['js-module'].uninstall(jsModule, www_dir, plugin_id);
 
-                expect(fs.removeSync).toHaveBeenCalledWith(path.join(www_dir, 'plugins', plugin_id));
+                expect(fs.rmSync).toHaveBeenCalledWith(path.join(www_dir, 'plugins', plugin_id), { recursive: true, force: true });
                 expect(events.emit).toHaveBeenCalledWith(
                     'verbose',
                     `js-module uninstall called : ${path.join('plugins', plugin_id, jsModule.src)}`
@@ -138,7 +138,7 @@ describe('Handler export', () => {
         const wwwDest = 'dest';
 
         describe('asset.install', () => {
-            it('should copySync assets to destination.', () => {
+            it('should cpSync assets to destination.', () => {
                 const asset = {
                     itemType: 'asset',
                     src: 'someSrc/ServiceWorker.js',
@@ -146,13 +146,13 @@ describe('Handler export', () => {
                 };
 
                 // Spies
-                spyOn(fs, 'copySync');
-                spyOn(fs, 'ensureDirSync').and.returnValue(true);
+                spyOn(fs, 'cpSync');
+                spyOn(fs, 'mkdirSync').and.returnValue(true);
 
                 handler.asset.install(asset, plugin_dir, wwwDest);
 
-                expect(fs.ensureDirSync).toHaveBeenCalled();
-                expect(fs.copySync).toHaveBeenCalledWith(jasmine.any(String), path.join('dest', asset.target));
+                expect(fs.mkdirSync).toHaveBeenCalled();
+                expect(fs.cpSync).toHaveBeenCalledWith(jasmine.any(String), path.join('dest', asset.target), { recursive: true });
             });
         });
 
@@ -162,13 +162,13 @@ describe('Handler export', () => {
                 const mockPluginId = 'com.foobar.random-plugin-id';
 
                 // Spies
-                spyOn(fs, 'removeSync').and.returnValue(true);
+                spyOn(fs, 'rmSync').and.returnValue(true);
 
                 handler.asset.uninstall(asset, wwwDest, mockPluginId);
 
-                expect(fs.removeSync).toHaveBeenCalled();
-                expect(fs.removeSync.calls.argsFor(0)[0]).toBe(path.join(wwwDest, asset.target));
-                expect(fs.removeSync.calls.argsFor(1)[0]).toBe(path.join(wwwDest, 'plugins', mockPluginId));
+                expect(fs.rmSync).toHaveBeenCalled();
+                expect(fs.rmSync.calls.argsFor(0)[0]).toBe(path.join(wwwDest, asset.target));
+                expect(fs.rmSync.calls.argsFor(1)[0]).toBe(path.join(wwwDest, 'plugins', mockPluginId));
             });
         });
     });
@@ -198,14 +198,14 @@ describe('Handler export', () => {
         const frameworkInstallPluginPackageFile = path.join(frameworkInstallPluginDir, 'src/electron/package.json');
 
         beforeEach(() => {
-            fs.ensureDirSync(tmpDir);
-            fs.copySync(path.resolve(fixturesDir, 'test-app-with-electron-plugin'), testProjectDir);
+            fs.mkdirSync(tmpDir, { recursive: true });
+            fs.cpSync(path.resolve(fixturesDir, 'test-app-with-electron-plugin'), testProjectDir, { recursive: true });
 
             spyOn(events, 'emit');
         });
 
         afterEach(() => {
-            fs.removeSync(tmpDir);
+            fs.rmSync(tmpDir, { recursive: true, force: true });
         });
 
         describe('framework.install', () => {

--- a/tests/spec/unit/lib/handler.spec.js
+++ b/tests/spec/unit/lib/handler.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const { events } = require('cordova-common');
 const rewire = require('rewire');

--- a/tests/spec/unit/lib/parser.spec.js
+++ b/tests/spec/unit/lib/parser.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const rewire = require('rewire');
 const { CordovaError, events } = require('cordova-common');

--- a/tests/spec/unit/lib/parser.spec.js
+++ b/tests/spec/unit/lib/parser.spec.js
@@ -18,7 +18,7 @@
 */
 
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const rewire = require('rewire');
 const { CordovaError, events } = require('cordova-common');
 
@@ -149,14 +149,14 @@ describe('Parser class', () => {
 
         describe('update_project method', () => {
             it('should copy munged config.xml to platform www dir.', () => {
-                const fsCopySyncSpy = jasmine.createSpy('copySync');
-                Parser.__set__('fs', { copySync: fsCopySyncSpy });
+                const cpSyncSpy = jasmine.createSpy('cpSync');
+                Parser.__set__('fs', { cpSync: cpSyncSpy });
 
                 parser.update_project().then(() => {
-                    const actualSrc = fsCopySyncSpy.calls.argsFor(0)[0];
-                    const actualDest = fsCopySyncSpy.calls.argsFor(0)[1];
+                    const actualSrc = cpSyncSpy.calls.argsFor(0)[0];
+                    const actualDest = cpSyncSpy.calls.argsFor(0)[1];
 
-                    expect(fsCopySyncSpy).toHaveBeenCalled();
+                    expect(cpSyncSpy).toHaveBeenCalled();
                     expect(actualSrc).toBe(path.join(mockProjectPath, 'config.xml'));
                     expect(actualDest).toBe(path.join(mockProjectPath, 'www', 'config.xml'));
                 });

--- a/tests/spec/unit/lib/prepare.spec.js
+++ b/tests/spec/unit/lib/prepare.spec.js
@@ -19,7 +19,7 @@
 
 const rewire = require('rewire');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const CordovaError = require('cordova-common').CordovaError;
 
 const rootDir = path.resolve(__dirname, '../../../..');
@@ -223,13 +223,13 @@ describe('Testing prepare.js:', () => {
         let api;
 
         beforeAll(() => {
-            fs.ensureDirSync(tmpDir);
-            fs.copySync(path.resolve(fixturesDir, 'testapp'), path.resolve(tmpDir, 'testapp'));
+            fs.mkdirSync(tmpDir, { recursive: true });
+            fs.cpSync(path.resolve(fixturesDir, 'testapp'), path.resolve(tmpDir, 'testapp'), { recursive: true });
             api = new Api(null, testProjectDir);
         });
 
         afterAll(() => {
-            fs.removeSync(tmpDir);
+            fs.rmSync(tmpDir, { recursive: true, force: true });
         });
 
         beforeEach(() => {
@@ -253,12 +253,12 @@ describe('Testing prepare.js:', () => {
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
                 const ownConfigPathMock = api.locations.configXml;
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         return configPath === defaultConfigPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -279,7 +279,7 @@ describe('Testing prepare.js:', () => {
 
                 prepare.prepare.call(api, cordovaProject, { }, api);
 
-                expect(copySyncSpy).toHaveBeenCalledWith(defaultConfigPathMock, ownConfigPathMock);
+                expect(cpSyncSpy).toHaveBeenCalledWith(defaultConfigPathMock, ownConfigPathMock, { recursive: true });
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
@@ -308,12 +308,12 @@ describe('Testing prepare.js:', () => {
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         return configPath === defaultConfigPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -357,12 +357,12 @@ describe('Testing prepare.js:', () => {
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         return configPath === defaultConfigPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -406,13 +406,13 @@ describe('Testing prepare.js:', () => {
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         if (configPath === defaultConfigPathMock) return true;
                         if (configPath.includes('fail_test_path')) return false;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -451,13 +451,13 @@ describe('Testing prepare.js:', () => {
                 api.parser.update_project = () => this;
 
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         if (configPath === defaultConfigPathMock) return true;
                         if (configPath.includes('pass_test_path')) return true;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -498,12 +498,12 @@ describe('Testing prepare.js:', () => {
                 const defaultConfigPathMock = path.join(api.locations.platformRootDir, 'cordova', 'defaults.xml');
                 const ownConfigPathMock = api.locations.configXml;
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         return configPath === ownConfigPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -524,7 +524,7 @@ describe('Testing prepare.js:', () => {
 
                 prepare.prepare.call(api, cordovaProject, { }, api);
 
-                expect(copySyncSpy).toHaveBeenCalledWith(ownConfigPathMock, defaultConfigPathMock);
+                expect(cpSyncSpy).toHaveBeenCalledWith(ownConfigPathMock, defaultConfigPathMock, { recursive: true });
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
@@ -555,12 +555,12 @@ describe('Testing prepare.js:', () => {
                 const ownConfigPathMock = api.locations.configXml;
                 const sourceCfgMock = cordovaProject.projectConfig;
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (configPath) {
                         return configPath !== ownConfigPathMock && configPath !== defaultConfigPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -581,7 +581,7 @@ describe('Testing prepare.js:', () => {
 
                 prepare.prepare.call(api, cordovaProject, { }, api);
 
-                expect(copySyncSpy).toHaveBeenCalledWith(sourceCfgMock.path, ownConfigPathMock);
+                expect(cpSyncSpy).toHaveBeenCalledWith(sourceCfgMock.path, ownConfigPathMock, { recursive: true });
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
@@ -611,12 +611,12 @@ describe('Testing prepare.js:', () => {
                 const srcManifestPathMock = path.join(cordovaProject.locations.www, 'manifest.json');
                 const manifestPathMock = path.join(api.locations.www, 'manifest.json');
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (srcManifestPath) {
                         return srcManifestPath === srcManifestPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -637,7 +637,7 @@ describe('Testing prepare.js:', () => {
 
                 prepare.prepare.call(api, cordovaProject, { }, api);
 
-                expect(copySyncSpy).toHaveBeenCalledWith(srcManifestPathMock, manifestPathMock);
+                expect(cpSyncSpy).toHaveBeenCalledWith(srcManifestPathMock, manifestPathMock, { recursive: true });
                 expect(mergeXmlSpy).toHaveBeenCalled();
                 expect(updateIconsSpy).toHaveBeenCalled();
                 expect(updateSplashScreensSpy).toHaveBeenCalled();
@@ -666,12 +666,12 @@ describe('Testing prepare.js:', () => {
 
                 const srcManifestPathMock = path.join(cordovaProject.locations.www, 'manifest.json');
 
-                const copySyncSpy = jasmine.createSpy('copySync');
+                const cpSyncSpy = jasmine.createSpy('cpSync');
                 prepare.__set__('fs', {
                     existsSync: function (srcManifestPath) {
                         return srcManifestPath !== srcManifestPathMock;
                     },
-                    copySync: copySyncSpy,
+                    cpSync: cpSyncSpy,
                     readFileSync: function (filePath) {
                         if (filePath === path.join('MOCK_PROJECT_ROOT', 'package.json')) {
                             return defaultMockProjectPackageJson;
@@ -1758,7 +1758,7 @@ describe('Testing prepare.js:', () => {
 
     describe('copyResources method', () => {
         let copyResources;
-        let fsCopySyncSpy;
+        let cpSyncSpy;
         let cordovaProject;
 
         beforeEach(() => {
@@ -1767,13 +1767,13 @@ describe('Testing prepare.js:', () => {
             cordovaProject = Object.assign({}, cordovaProjectDefault);
             copyResources = prepare.__get__('copyResources');
 
-            fsCopySyncSpy = jasmine.createSpy('copySync');
-            prepare.__set__('fs', { copySync: fsCopySyncSpy });
+            cpSyncSpy = jasmine.createSpy('cpSync');
+            prepare.__set__('fs', { cpSync: cpSyncSpy });
         });
 
         it('should not copy as no resources provided.', () => {
             copyResources(cordovaProject.root, [{}]);
-            expect(fsCopySyncSpy).not.toHaveBeenCalled();
+            expect(cpSyncSpy).not.toHaveBeenCalled();
         });
 
         it('should copy provided resources.', () => {
@@ -1782,15 +1782,15 @@ describe('Testing prepare.js:', () => {
                 { [path.join('res', 'electron', 'cordova.png')]: path.join(cordovaProject.root, 'www', 'img', 'icon.png') }
             ]);
 
-            expect(fsCopySyncSpy).toHaveBeenCalled();
+            expect(cpSyncSpy).toHaveBeenCalled();
 
-            const installerIconSrcPathTest = fsCopySyncSpy.calls.argsFor(0)[0];
-            const installerIconDestPathTest = fsCopySyncSpy.calls.argsFor(0)[1];
+            const installerIconSrcPathTest = cpSyncSpy.calls.argsFor(0)[0];
+            const installerIconDestPathTest = cpSyncSpy.calls.argsFor(0)[1];
             expect(installerIconSrcPathTest).toBe(path.join(cordovaProject.root, 'res', 'electron', 'cordova_512.png'));
             expect(installerIconDestPathTest).toBe(path.join(cordovaProject.root, 'build-res', 'installer.png'));
 
-            const appIconSrcPathTest = fsCopySyncSpy.calls.argsFor(1)[0];
-            const appIconDestPathTest = fsCopySyncSpy.calls.argsFor(1)[1];
+            const appIconSrcPathTest = cpSyncSpy.calls.argsFor(1)[0];
+            const appIconDestPathTest = cpSyncSpy.calls.argsFor(1)[1];
             expect(appIconSrcPathTest).toBe(path.join(cordovaProject.root, 'res', 'electron', 'cordova.png'));
             expect(appIconDestPathTest).toBe(path.join(cordovaProject.root, 'www', 'img', 'icon.png'));
         });

--- a/tests/spec/unit/lib/prepare.spec.js
+++ b/tests/spec/unit/lib/prepare.spec.js
@@ -18,7 +18,7 @@
 */
 
 const rewire = require('rewire');
-const path = require('path');
+const path = require('node:path');
 const fs = require('node:fs');
 const CordovaError = require('cordova-common').CordovaError;
 

--- a/tests/spec/unit/lib/run.spec.js
+++ b/tests/spec/unit/lib/run.spec.js
@@ -18,7 +18,7 @@
 */
 
 const rewire = require('rewire');
-const path = require('path');
+const path = require('node:path');
 
 const rootDir = path.resolve(__dirname, '../../../..');
 

--- a/tests/spec/unit/lib/util.spec.js
+++ b/tests/spec/unit/lib/util.spec.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const path = require('path');
+const path = require('node:path');
 
 const rootDir = path.resolve(__dirname, '../../../..');
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Modernaize code

### Description
<!-- Describe your changes in detail -->

- Use Node Internal Modules `node:*`
- Replace `fs-extra` with `node:fs`
- Improve PackageJsonParser testing

### Testing
<!-- Please describe in detail how you tested your changes. -->

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
