### PR TITLE
ci: use macos-15 instead of macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [20.x, 22.x, 24.x]
+        os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,8 @@ jobs:
 
       - uses: github/codeql-action/analyze@v3
 
-      - uses: codecov/codecov-action@v4
+      # v4.6.0
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         if: success()
         with:
           name: ${{ runner.os }} node.js ${{ matrix.node-version }}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Use `macos-15` in CI

### Description
<!-- Describe your changes in detail -->

- Replaced `macos-latest` with `macos-15`
- Updated node range
- Pinned Codecov

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
